### PR TITLE
feat: add preview mode

### DIFF
--- a/cypress/e2e/player/island.cy.ts
+++ b/cypress/e2e/player/island.cy.ts
@@ -7,7 +7,7 @@ import {
 import {
   ITEM_CHATBOX_BUTTON_ID,
   ITEM_MAP_BUTTON_ID,
-  NAVIGATION_ISLAND_ID,
+  NAVIGATION_ISLAND_CLASSNAME,
   buildDocumentId,
   buildTreeItemClass,
 } from '../../../src/config/selectors';
@@ -118,6 +118,7 @@ describe('Island', () => {
     });
   });
 
+  // test is flaky
   it('Shows only one island when folder contains shortcut', () => {
     const items = getFolderWithShortcutFixture();
     const parent = items[0];
@@ -128,7 +129,7 @@ describe('Island', () => {
       'contain',
       getDocumentExtra(documentTarget.extra as DocumentItemExtra).content,
     );
-    cy.get(`#${NAVIGATION_ISLAND_ID}`)
+    cy.get(`.${NAVIGATION_ISLAND_CLASSNAME}`)
       .should('be.visible')
       .and('have.length', 1);
   });

--- a/src/config/selectors.ts
+++ b/src/config/selectors.ts
@@ -179,7 +179,7 @@ export const FORBIDDEN_CONTENT_CONTAINER_ID = 'forbiddenContentContainer';
 
 export const USER_SWITCH_SIGN_IN_BUTTON_ID = 'userSwitchSignInButton';
 
-export const NAVIGATION_ISLAND_ID = 'navigationIsland';
+export const NAVIGATION_ISLAND_CLASSNAME = 'navigationIsland';
 export const ITEM_CHATBOX_BUTTON_ID = 'itemChatboxButton';
 export const ITEM_MAP_BUTTON_ID = 'itemMapButton';
 export const ITEM_PINNED_BUTTON_ID = 'itemPinnedButton';

--- a/src/modules/landing/footer/CopyrightText.stories.tsx
+++ b/src/modules/landing/footer/CopyrightText.stories.tsx
@@ -1,0 +1,14 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { CopyrightText } from './CopyrightText';
+
+const meta = {
+  component: CopyrightText,
+} satisfies Meta<typeof CopyrightText>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+  args: {},
+} satisfies Story;

--- a/src/modules/landing/footer/CopyrightText.tsx
+++ b/src/modules/landing/footer/CopyrightText.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+import { Typography } from '@mui/material';
+
+import { usePreviewMode } from '~landing/preview/PreviewModeContext';
+
+export function CopyrightText() {
+  const [clickCounter, setClickCounter] = useState(0);
+  const { togglePreview, isEnabled: isPreviewEnabled } = usePreviewMode();
+
+  const handleClick = () => {
+    if (clickCounter === 2) {
+      togglePreview();
+      // reset counter
+      setClickCounter(0);
+    } else {
+      setClickCounter((s) => s + 1);
+    }
+  };
+  return (
+    <Typography textAlign="center" variant="note" onClick={handleClick}>
+      &copy; Graasp 2014 - {new Date().getFullYear()}
+      {isPreviewEnabled ? ' (preview)' : ''}
+    </Typography>
+  );
+}

--- a/src/modules/landing/footer/CopyrightText.tsx
+++ b/src/modules/landing/footer/CopyrightText.tsx
@@ -18,7 +18,12 @@ export function CopyrightText() {
     }
   };
   return (
-    <Typography textAlign="center" variant="note" onClick={handleClick}>
+    <Typography
+      textAlign="center"
+      variant="note"
+      onClick={handleClick}
+      sx={{ userSelect: 'none' }}
+    >
       &copy; Graasp 2014 - {new Date().getFullYear()}
       {isPreviewEnabled ? ' (preview)' : ''}
     </Typography>

--- a/src/modules/landing/footer/Footer.tsx
+++ b/src/modules/landing/footer/Footer.tsx
@@ -8,6 +8,7 @@ import LanguageSwitch from '@/components/ui/LanguageSwitch';
 import { NS } from '@/config/constants';
 import { OnChangeLangProp } from '@/types';
 
+import { CopyrightText } from './CopyrightText';
 import { FooterSection } from './FooterSection';
 import {
   FacebookIcon,
@@ -191,9 +192,7 @@ export function Footer({ onChangeLang }: Readonly<FooterProps>): JSX.Element {
           alignItems="center"
           justifyContent="center"
         >
-          <Typography textAlign="center" variant="note">
-            &copy; Graasp 2014 - {new Date().getFullYear()}
-          </Typography>
+          <CopyrightText />
         </Stack>
       </Stack>
     </Stack>

--- a/src/modules/landing/preview/PreviewModeContext.tsx
+++ b/src/modules/landing/preview/PreviewModeContext.tsx
@@ -1,0 +1,74 @@
+import {
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+const PREVIEW_STORAGE_KEY = 'graasp-preview';
+
+type PreviewContextType = {
+  togglePreview: () => void;
+  isEnabled: boolean;
+};
+const PreviewContext = createContext<PreviewContextType>({
+  isEnabled: false,
+  togglePreview: () => console.error('no Preview context present'),
+});
+
+const isPreviewEnabled = () => {
+  const isPresent = localStorage.getItem(PREVIEW_STORAGE_KEY) != null;
+  return isPresent;
+};
+
+export function PreviewContextProvider({
+  children,
+}: Readonly<{ children: ReactNode }>) {
+  const [isEnabled, setIsEnabled] = useState(isPreviewEnabled());
+
+  useEffect(() => {
+    function listenForStorageChanges(event: StorageEvent) {
+      if (event.key === PREVIEW_STORAGE_KEY) {
+        // sync the local state
+        setIsEnabled(isPreviewEnabled());
+      }
+      // discard the event otherwise
+    }
+    window.addEventListener('storage', listenForStorageChanges);
+    return () => window.removeEventListener('storage', listenForStorageChanges);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      togglePreview: () => {
+        if (isPreviewEnabled()) {
+          window.localStorage.removeItem(PREVIEW_STORAGE_KEY);
+          setIsEnabled(false);
+        } else {
+          window.localStorage.setItem(PREVIEW_STORAGE_KEY, 'enabled');
+          setIsEnabled(true);
+        }
+      },
+      isEnabled,
+    }),
+    [isEnabled],
+  );
+
+  return (
+    <PreviewContext.Provider value={value}>{children}</PreviewContext.Provider>
+  );
+}
+
+export function usePreviewMode() {
+  return useContext<PreviewContextType>(PreviewContext);
+}
+
+export function Preview({ children }: { children: ReactNode }) {
+  const { isEnabled } = usePreviewMode();
+  if (isEnabled) {
+    return children;
+  }
+  return null;
+}

--- a/src/modules/player/navigationIsland/NavigationIsland.tsx
+++ b/src/modules/player/navigationIsland/NavigationIsland.tsx
@@ -1,6 +1,6 @@
 import { Box, Stack } from '@mui/material';
 
-import { NAVIGATION_ISLAND_ID } from '@/config/selectors';
+import { NAVIGATION_ISLAND_CLASSNAME } from '@/config/selectors';
 
 import useChatButton from './ChatButton';
 import useGeolocationButton from './GeolocationButton';
@@ -26,7 +26,7 @@ const NavigationIslandBox = (): JSX.Element | null => {
 
   return (
     <Box
-      id={NAVIGATION_ISLAND_ID}
+      className={NAVIGATION_ISLAND_CLASSNAME}
       // set some background and shadow
       bgcolor="white"
       boxShadow="0px 3px 6px 0px rgba(0, 0, 0, 0.25)"

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -12,6 +12,8 @@ import { AuthContextType } from '@/AuthContext';
 import { NotFoundComponent } from '@/components/NotFoundComponent';
 import { ReactQueryDevtools } from '@/config/queryClient';
 
+import { PreviewContextProvider } from '~landing/preview/PreviewModeContext';
+
 export const Route = createRootRouteWithContext<{ auth: AuthContextType }>()({
   component: RootComponent,
   notFoundComponent: NotFoundComponent,
@@ -32,7 +34,9 @@ function RootComponent() {
   return (
     <Stack id="__root">
       <ScrollRestoration />
-      <Outlet />
+      <PreviewContextProvider>
+        <Outlet />
+      </PreviewContextProvider>
       {import.meta.env.MODE !== 'test' && <ReactQueryDevtools />}
       <Suspense>
         <TanStackRouterDevtools />

--- a/src/routes/_landing.tsx
+++ b/src/routes/_landing.tsx
@@ -19,6 +19,7 @@ import { OnChangeLangProp } from '@/types';
 
 import { Footer } from '~landing/footer/Footer';
 import { RightHeader } from '~landing/header/RightHeader';
+import { usePreviewMode } from '~landing/preview/PreviewModeContext';
 
 export const Route = createFileRoute('/_landing')({
   component: RouteComponent,
@@ -30,7 +31,7 @@ function RouteComponent() {
   const { isMobile } = useMobileView();
   const { fill: primary } = useButtonColor('primary');
   const { mutate } = mutations.useEditCurrentMember();
-
+  const { isEnabled: isPreviewEnabled } = usePreviewMode();
   const onChangeLang: OnChangeLangProp = (lang: string) => {
     if (isAuthenticated) {
       mutate({ extra: { lang } });
@@ -76,7 +77,12 @@ function RouteComponent() {
             <GraaspLogo height={44} sx={{ fill: primary! }} />
             {!isMobile && (
               <Typography fontWeight="bold" variant="h2" color="primary">
-                Graasp
+                Graasp{' '}
+                {isPreviewEnabled ? (
+                  <Typography variant="note">preview</Typography>
+                ) : (
+                  ''
+                )}
               </Typography>
             )}
           </Stack>

--- a/src/routes/_landing/features.tsx
+++ b/src/routes/_landing/features.tsx
@@ -4,7 +4,9 @@ import { BlendedLearningSection } from '~landing/features/BlendedLearningSection
 import { GraaspFeaturesSection } from '~landing/features/GraaspFeaturesSection';
 import { PlatformOverviewSection } from '~landing/features/PlatformOverviewSection';
 import { TitleSection } from '~landing/features/TitleSection';
+import { PricingPlansSection } from '~landing/features/pricing/PricingPlansSection';
 import { NewsLetter } from '~landing/home/NewsLetter';
+import { Preview } from '~landing/preview/PreviewModeContext';
 
 export const Route = createFileRoute('/_landing/features')({
   component: RouteComponent,
@@ -17,8 +19,12 @@ function RouteComponent() {
       <PlatformOverviewSection />
       <BlendedLearningSection />
       <GraaspFeaturesSection />
-      {/* <PricingPlansSection /> */}
-      {/* <BlogSection /> */}
+      <Preview>
+        <PricingPlansSection />
+      </Preview>
+      {/* <Preview>
+        <BlogSection />
+      </Preview> */}
       <NewsLetter />
     </>
   );


### PR DESCRIPTION
In this PR:
- fix #532 

https://github.com/user-attachments/assets/54782209-0786-435c-8d64-e7ba6cce45e5

## How it works

When you triple click on the copy right text it enables the "Preview" mode. The graasp logo show that you are in "Preview Mode, the copy right text as well. 

It adds a localStorage item.

It shows components guarded by `Preview` wrappers. This allows to push changes but not make them available to customers directly. 

## Potential extension

Currently only a single key is used and its presence is used to show or hide content.

We could extend this feature to specific feature sets, like `landing`, `ui` etc ... that would allow to selectively have control over the preview features you want to enable. 
