### PR TITLE
fix: analytics navigator arrow is miss-aligned

### DIFF
--- a/src/components/ui/Navigator/CurrentItemNavigation.tsx
+++ b/src/components/ui/Navigator/CurrentItemNavigation.tsx
@@ -25,7 +25,7 @@ export function CurrentItemNavigation({
   showArrow,
 }: Readonly<CurrentItemProps>): JSX.Element | null {
   return (
-    <Stack alignItems="center">
+    <Stack direction="row" alignItems="center">
       <TypographyLink
         id={buildBreadcrumbsItemLinkId?.(item.id)}
         key={item.id}

--- a/src/components/ui/Navigator/ParentsNavigation.tsx
+++ b/src/components/ui/Navigator/ParentsNavigation.tsx
@@ -17,7 +17,7 @@ export function ParentsNavigation({
   buildBreadcrumbsItemLinkId,
 }: Readonly<ParentsProps>): JSX.Element {
   return (
-    <Stack direction="row">
+    <Stack direction="row" alignItems="center">
       {parents.map(({ name, id }) => (
         <Stack
           key={id}

--- a/src/modules/analytics/Navigator.tsx
+++ b/src/modules/analytics/Navigator.tsx
@@ -14,15 +14,11 @@ const { useItem, useParents, useChildren } = hooks;
 export function Navigator({
   itemId,
 }: Readonly<{ itemId: string }>): JSX.Element | null {
-  const { data: item, isLoading: isItemLoading } = useItem(itemId);
+  const { data: item } = useItem(itemId);
 
-  const { data: parents, isLoading: areParentsLoading } = useParents({
+  const { data: parents } = useParents({
     id: itemId,
   });
-
-  if (isItemLoading || areParentsLoading) {
-    return null;
-  }
 
   return (
     <AnalyticsNavigator


### PR DESCRIPTION
In this PR I fix a silly bug related to the navigator in analytics.

The children arrow was incorrectly aligned below the element name when it should be in the same row.

I also removed the laoding states to decrease the flickering when navigating between items.
