### PR TITLE
fix: umami event on navigation cause full-page reload

### DIFF
--- a/src/components/ui/MainMenuItem.tsx
+++ b/src/components/ui/MainMenuItem.tsx
@@ -28,7 +28,14 @@ const MUILinkComponent = React.forwardRef<
   HTMLAnchorElement,
   MUIListItemButtonProps
 >((props, ref) => {
-  const { id, icon, text, dataUmamiEvent, onClick, ...rest } = props;
+  const {
+    id,
+    icon,
+    text,
+    // dataUmamiEvent,
+    onClick,
+    ...rest
+  } = props;
   const { isMobile } = useMobileView();
   const { setOpen } = useMainMenuOpenContext();
 
@@ -45,7 +52,7 @@ const MUILinkComponent = React.forwardRef<
       <ListItemButton
         component={'a'}
         ref={ref}
-        data-umami-event={dataUmamiEvent}
+        // data-umami-event={dataUmamiEvent}
         onClick={onClickHandler}
         {...rest}
       >

--- a/src/modules/builder/components/main/MainMenu.tsx
+++ b/src/modules/builder/components/main/MainMenu.tsx
@@ -35,7 +35,7 @@ const ResourceLinks = () => {
       <ListItemButton
         href={TUTORIALS_LINK}
         target="_blank"
-        data-umami-event="sidebar-tutorials"
+        // data-umami-event="sidebar-tutorials"
       >
         <ListItemIcon>
           <BookOpenTextIcon />

--- a/src/routes/builder/_layout.tsx
+++ b/src/routes/builder/_layout.tsx
@@ -62,8 +62,8 @@ const StyledLink = styled(Link)(() => ({
 }));
 const LinkComponent = ({ children }: { children: ReactNode }) => (
   <StyledLink
-    data-umami-event="header-home-link"
-    data-umami-event-context={Context.Builder}
+    // data-umami-event="header-home-link"
+    // data-umami-event-context={Context.Builder}
     to="/account"
   >
     {children}

--- a/src/routes/builder/items/$itemId.tsx
+++ b/src/routes/builder/items/$itemId.tsx
@@ -64,8 +64,8 @@ const StyledLink = styled(Link)(() => ({
 }));
 const LinkComponent = ({ children }: { children: ReactNode }) => (
   <StyledLink
-    data-umami-event="header-home-link"
-    data-umami-event-context={Context.Builder}
+    // data-umami-event="header-home-link"
+    // data-umami-event-context={Context.Builder}
     to="/account"
   >
     {children}

--- a/src/ui/Main/Main.tsx
+++ b/src/ui/Main/Main.tsx
@@ -196,7 +196,7 @@ const MainWithDrawerContent = ({
               >
                 {open ? <MenuOpen /> : <MenuIcon />}
               </IconButton>
-              {LinkComponent && LinkComponent({ children: <LogoHeader /> })}
+              {LinkComponent?.({ children: <LogoHeader /> })}
               {PlatformComponent}
               {headerLeftContent}
             </Stack>

--- a/src/ui/MainMenu/MenuItem/MenuItem.tsx
+++ b/src/ui/MainMenu/MenuItem/MenuItem.tsx
@@ -22,7 +22,7 @@ export type MenuItemProps = {
   /**
    * Name of the event that will be sent to Umami for tracking user actions
    */
-  dataUmamiEvent?: string;
+  // dataUmamiEvent?: string;
 };
 
 export const MenuItem = ({
@@ -33,7 +33,7 @@ export const MenuItem = ({
   text,
   selected,
   disabled,
-  dataUmamiEvent,
+  // dataUmamiEvent,
 }: MenuItemProps): JSX.Element => {
   const { setOpen } = useMainMenuOpenContext();
   const { isMobile } = useMobileView();
@@ -51,7 +51,7 @@ export const MenuItem = ({
         onClick={onNavigate}
         disabled={disabled}
         selected={selected}
-        data-umami-event={dataUmamiEvent}
+        // data-umami-event={dataUmamiEvent}
       >
         {icon && <ListItemIcon>{icon}</ListItemIcon>}
         {text && <ListItemText primary={text} />}

--- a/src/ui/PlatformSwitch/PlatformSwitch.tsx
+++ b/src/ui/PlatformSwitch/PlatformSwitch.tsx
@@ -133,7 +133,7 @@ export const PlatformSwitch = ({
           data-testid={platform}
           href={!platformProps?.disabled ? platformProps?.href : undefined}
           aria-disabled={platformProps?.disabled}
-          data-umami-event={`header-navigation-switch-${platform}`}
+          // data-umami-event={`header-navigation-switch-${platform}`}
         >
           <Icon
             disabledColor={disabledColor}


### PR DESCRIPTION
I have the impression that sending umami events on page navigation causes full-page reloads. This is not intended.

I think we should stick to sending "events" when user interact with buttons in the interface that have JS actions, for navigation related events we should either use the explicit umami.track method or rely simply on navigation tracking (the dashboard shows which pages were accessed).

I am open to discussions and maybe we need to investigate this a bit more.

