### PR TITLE
fix: disable navigation to player and analytics home from account

### DIFF
--- a/src/modules/account/PageWrapper.tsx
+++ b/src/modules/account/PageWrapper.tsx
@@ -49,13 +49,13 @@ export function PageWrapper({
       href: '/builder',
     },
     [Platform.Player]: {
-      href: '/player',
+      disabled: true,
     },
     [Platform.Library]: {
       href: GRAASP_LIBRARY_HOST,
     },
     [Platform.Analytics]: {
-      href: '/analytics',
+      disabled: true,
     },
   };
 


### PR DESCRIPTION
In this PR I make a small fix to disable the navigation to `/player` and `/analytics` from the home of account since the bare pages are not very usefull in this context.

For example the player page just redirects back to /account ... so there is not a lot of use.
