### PR TITLE
fix: h5p integration and require h5p env var in prod build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
         run: pnpm build
         env:
           VITE_RECAPTCHA_SITE_KEY: 123456789
+          VITE_GRAASP_H5P_INTEGRATION_URL: http://integration.url/mock-value.html
 
       - name: Get Latest playwright version
         run: echo "PLAYWRIGHT_VERSION=$(pnpm show playwright version)" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
         run: pnpm build
         env:
           VITE_RECAPTCHA_SITE_KEY: 123456789
+          VITE_GOOGLE_KEY: 1234567890
           VITE_GRAASP_H5P_INTEGRATION_URL: http://integration.url/mock-value.html
 
       - name: Get Latest playwright version

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -15,8 +15,16 @@ export const GRAASP_REDIRECTION_HOST = import.meta.env
   .VITE_GRAASP_REDIRECTION_HOST;
 export const RECAPTCHA_SITE_KEY = import.meta.env.VITE_RECAPTCHA_SITE_KEY;
 
+// expect integration url to be present in production
+// we should not use the backend integration in production as it exposes the cookies to the h5p files if they are served on the same domain.
+if (import.meta.env.PROD && !import.meta.env.VITE_GRAASP_H5P_INTEGRATION_URL) {
+  throw new Error(
+    "Missing required env variable in production: 'VITE_GRAASP_H5P_INTEGRATION_URL'",
+  );
+}
+
 export const H5P_INTEGRATION_URL =
-  import.meta.env.VITE_GRAASP_H5P_INTEGRATION_URL ||
+  import.meta.env.VITE_GRAASP_H5P_INTEGRATION_URL ??
   `${API_HOST}/items/h5p-assets/integration.html`;
 
 // Question: should we host the pdf player assets inside the public directory here instead of at another bucket ?

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -15,14 +15,12 @@ export const GRAASP_REDIRECTION_HOST = import.meta.env
   .VITE_GRAASP_REDIRECTION_HOST;
 export const RECAPTCHA_SITE_KEY = import.meta.env.VITE_RECAPTCHA_SITE_KEY;
 
-// expect integration url to be present in production
-// we should not use the backend integration in production as it exposes the cookies to the h5p files if they are served on the same domain.
-if (import.meta.env.PROD && !import.meta.env.VITE_GRAASP_H5P_INTEGRATION_URL) {
-  throw new Error(
-    "Missing required env variable in production: 'VITE_GRAASP_H5P_INTEGRATION_URL'",
-  );
-}
-
+/**
+ * The integration url needed to display H5P content
+ *
+ * It's value is required in production since it is not recommended to use the fallback backend endpoint.
+ * The backend endpoint is considered in-secure when the app and the backend are hosted on a domain where cookies are shared.
+ */
 export const H5P_INTEGRATION_URL =
   import.meta.env.VITE_GRAASP_H5P_INTEGRATION_URL ??
   `${API_HOST}/items/h5p-assets/integration.html`;
@@ -31,4 +29,9 @@ export const H5P_INTEGRATION_URL =
 // Are there any security implications if it is hosted on the same domain as the app code ?
 export const GRAASP_ASSETS_URL = import.meta.env.VITE_GRAASP_ASSETS_URL;
 
+/**
+ * Required API Key to use google map api in analytics.
+ *
+ * This could maybe be replaced by our own map implementation if we want using react-leaflet.
+ */
 export const GOOGLE_KEY = import.meta.env.VITE_GOOGLE_KEY;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,6 +25,13 @@ const config = ({ mode }: { mode: string }): UserConfig => {
     VITE_UMAMI_HOST,
     VITE_GRAASP_API_HOST,
   } = process.env;
+
+  // ensure required variables are present
+  if (mode === 'production') {
+    requireEnvVariable('VITE_GRAASP_H5P_INTEGRATION_URL');
+    requireEnvVariable('VITE_GOOGLE_KEY');
+  }
+
   // compute the port to use
   const PORT = parseInt(VITE_PORT ?? '3114', 10);
   // compute whether we should open the browser
@@ -99,3 +106,16 @@ const config = ({ mode }: { mode: string }): UserConfig => {
   });
 };
 export default config;
+
+function requireEnvVariable(varName: string) {
+  if (!process.env[varName]) {
+    const message = `Missing required env variable for production build: '${varName}'`;
+    const messageLength = message.length;
+    const straightSection = Array(messageLength + 4)
+      .fill('═')
+      .join('');
+    const pad = '   ';
+    const borderedMessage = `\n\n${pad}╔${straightSection}╗\n${pad}║  ${message}  ║\n${pad}╚${straightSection}╝\n`;
+    throw new Error(borderedMessage);
+  }
+}


### PR DESCRIPTION
In this PR I make the H5P integration env var required when we make a production build.

I also update the url of the h5p integration provided by the backend when we are in dev as it is easier than having to deploy a separate h5p bucket with the integration.
The route had changed. There will be a PR in the backend to update it.

Below is an example of the error message that is displayed when the var is missing:
<img width="916" alt="Screenshot 2025-01-24 at 10 44 21" src="https://github.com/user-attachments/assets/dece25c8-8e92-496e-9558-0bd68ea9c49b" />

It is possible to require any env var by name in the build process by calling `requireEnvVariable("MYVAR")`.


