### PR TITLE
fix: modal titles

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -49,7 +49,7 @@ export function AuthProvider({
 }: Readonly<{
   children: ReactNode;
 }>): JSX.Element {
-  const { data: currentMember, isLoading } = hooks.useCurrentMember();
+  const { data: currentMember, isPending } = hooks.useCurrentMember();
   const useLogin = mutations.useSignIn();
   const useLogout = mutations.useSignOut();
 
@@ -105,10 +105,9 @@ export function AuthProvider({
   }, [currentMember, login, logout]);
 
   // if the query has not resolved yet, we can not render the rest of the tree
-  if (isLoading) {
+  if (isPending) {
     return <CustomInitialLoader />;
   }
-
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 

--- a/src/modules/builder/components/item/copy/CopyModal.tsx
+++ b/src/modules/builder/components/item/copy/CopyModal.tsx
@@ -41,7 +41,7 @@ export const CopyModal = ({
 
   return (
     <ItemSelectionModal
-      titleKey={BUILDER.COPY_ITEM_MODAL_TITLE}
+      title={translateBuilder(BUILDER.COPY_ITEM_MODAL_TITLE)}
       buttonText={buttonText}
       onClose={onClose}
       open={open}

--- a/src/modules/builder/components/item/move/MoveModal.tsx
+++ b/src/modules/builder/components/item/move/MoveModal.tsx
@@ -71,7 +71,7 @@ export const MoveModal = ({
 
   return items ? (
     <ItemSelectionModal
-      titleKey={BUILDER.MOVE_ITEM_MODAL_TITLE}
+      title={translateBuilder(BUILDER.MOVE_ITEM_MODAL_TITLE)}
       isDisabled={isDisabled}
       buttonText={buttonText}
       onClose={onClose}

--- a/src/modules/builder/components/item/sharing/csvImport/TemplateSelectionButton.tsx
+++ b/src/modules/builder/components/item/sharing/csvImport/TemplateSelectionButton.tsx
@@ -91,7 +91,7 @@ const TemplateSelectionButton = ({
 
       {targetItemId && open && (
         <ItemSelectionModal
-          titleKey={BUILDER.ITEM_TEMPLATE_SELECTION_MODAL_TITLE}
+          title={t(BUILDER.ITEM_TEMPLATE_SELECTION_MODAL_TITLE)}
           buttonText={buttonText}
           onClose={onClose}
           open={open}

--- a/src/modules/builder/components/item/shortcut/CreateShortcutModal.tsx
+++ b/src/modules/builder/components/item/shortcut/CreateShortcutModal.tsx
@@ -56,7 +56,7 @@ const CreateShortcutModal = ({
   if (item && open) {
     return (
       <ItemSelectionModal
-        titleKey={BUILDER.CREATE_SHORTCUT_MODAL_TITLE}
+        title={translateBuilder(BUILDER.CREATE_SHORTCUT_MODAL_TITLE)}
         buttonText={buttonText}
         onClose={onClose}
         open={open}

--- a/src/modules/builder/components/main/itemSelectionModal/ItemSelectionModal.tsx
+++ b/src/modules/builder/components/main/itemSelectionModal/ItemSelectionModal.tsx
@@ -25,7 +25,7 @@ import Breadcrumbs from '@/ui/Tree/Breadcrumbs';
 import type { NavigationElement } from '@/ui/Tree/types';
 
 import { BUILDER } from '../../../langs';
-import CancelButton from '../../common/CancelButton';
+import { CancelButton } from '../../common/CancelButton';
 import AccessibleNavigationTree from './AccessibleNavigationTree';
 import ChildrenNavigationTree from './ChildrenNavigationTree';
 import RootNavigationTree from './RootNavigationTree';
@@ -48,7 +48,7 @@ export type ItemSelectionModalProps = {
   onClose: (args: { id: string | null; open: boolean }) => void;
   onConfirm: (destination: string | undefined) => void;
   open?: boolean;
-  titleKey: string;
+  title: string;
 };
 const ItemSelectionModal = ({
   buttonText = () => 'Submit',
@@ -57,12 +57,11 @@ const ItemSelectionModal = ({
   onClose,
   onConfirm,
   open = false,
-  // titleKey,
+  title,
 }: ItemSelectionModalProps): JSX.Element => {
   const { t: translateBuilder } = useTranslation(NS.Builder);
   const { data: items, isLoading } = hooks.useItems(itemIds);
-  // todo: title is broken because of translations
-  // const title = items ? translateBuilder(titleKey) : <Skeleton height={50} />;
+  const titleElement = items ? title : <Skeleton height={50} />;
 
   // special elements for breadcrumbs
   // root displays specific paths
@@ -122,12 +121,7 @@ const ItemSelectionModal = ({
       open={open}
       scroll="paper"
     >
-      <DialogTitle id={dialogId}>
-        {
-          'Fix me title'
-          // title
-        }
-      </DialogTitle>
+      <DialogTitle id={dialogId}>{titleElement}</DialogTitle>
       <DialogContent>
         <Stack
           direction="column"


### PR DESCRIPTION
Fixing some modal titles that were left broken during the builder integration.

I moved the translation on the calling side to make it better on the type-checking of the translations. 