### PR TITLE
fix: navigation buttons issues

### DIFF
--- a/cypress/e2e/player/navigation.cy.ts
+++ b/cypress/e2e/player/navigation.cy.ts
@@ -5,32 +5,44 @@ import {
 } from '@graasp/sdk';
 
 import {
-  HOME_PAGE_PAGINATION_ID,
+  NEXT_ITEM_NAV_BUTTON_ID,
+  PREVIOUS_ITEM_NAV_BUTTON_ID,
   TREE_VIEW_ID,
-  buildHomePaginationId,
   buildTreeItemClass,
 } from '../../../src/config/selectors';
 import {
   FOLDER_WITH_SUBFOLDER_ITEM,
   FOLDER_WITH_SUBFOLDER_ITEM_AND_PARTIAL_ORDER,
-  generateLotsOfFoldersOnHome,
 } from '../../fixtures/items';
 import { CURRENT_MEMBER } from '../../fixtures/members';
 import { buildContentPagePath, buildMainPath } from './utils';
 
-const items = generateLotsOfFoldersOnHome({ folderCount: 20 });
-
 describe('Navigation', () => {
-  // skipped for the moment
-  it.skip('Show navigation on Home', () => {
-    cy.setUpApi({
-      items: [...items],
-    });
-    cy.visit('/');
+  it('Show navigation island on root item', () => {
+    cy.setUpApi({ items: FOLDER_WITH_SUBFOLDER_ITEM.items });
+    const rootId = FOLDER_WITH_SUBFOLDER_ITEM.items[0].id;
+    const itemId = FOLDER_WITH_SUBFOLDER_ITEM.items[1].id;
+    const rootPage = buildContentPagePath({ rootId, itemId: rootId });
+    cy.visit(rootPage);
 
-    cy.wait(['@getCurrentMember', '@getAccessibleItems']);
-    cy.get(`#${HOME_PAGE_PAGINATION_ID}`).scrollIntoView().should('be.visible');
-    cy.get(`#${buildHomePaginationId(2)}`).click();
+    // previous should be disabled, but visible
+    cy.get(`#${PREVIOUS_ITEM_NAV_BUTTON_ID}`)
+      .should('be.visible')
+      .and('not.have.attr', 'href');
+
+    // next should be visible and enabled
+    cy.get(`#${NEXT_ITEM_NAV_BUTTON_ID}`).should('be.visible').click();
+    cy.url().should('contain', buildContentPagePath({ rootId, itemId }));
+    // both previous and next are enabled
+    cy.get(`#${PREVIOUS_ITEM_NAV_BUTTON_ID}`)
+      .should('be.visible')
+      .and('have.attr', 'href');
+    cy.get(`#${NEXT_ITEM_NAV_BUTTON_ID}`)
+      .should('be.visible')
+      .and('have.attr', 'href');
+
+    cy.get(`#${PREVIOUS_ITEM_NAV_BUTTON_ID}`).click();
+    cy.url().should('contain', rootPage);
   });
 
   it('Expand folder when navigating', () => {

--- a/src/config/selectors.ts
+++ b/src/config/selectors.ts
@@ -187,6 +187,8 @@ export const FORBIDDEN_CONTENT_CONTAINER_ID = 'forbiddenContentContainer';
 export const USER_SWITCH_SIGN_IN_BUTTON_ID = 'userSwitchSignInButton';
 
 export const NAVIGATION_ISLAND_CLASSNAME = 'navigationIsland';
+export const PREVIOUS_ITEM_NAV_BUTTON_ID = 'prevNavButton';
+export const NEXT_ITEM_NAV_BUTTON_ID = 'nextNavButton';
 export const ITEM_CHATBOX_BUTTON_ID = 'itemChatboxButton';
 export const ITEM_MAP_BUTTON_ID = 'itemMapButton';
 export const ITEM_PINNED_BUTTON_ID = 'itemPinnedButton';

--- a/src/modules/player/navigationIsland/PreviousNextButtons.tsx
+++ b/src/modules/player/navigationIsland/PreviousNextButtons.tsx
@@ -7,6 +7,10 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 import { useAuth } from '@/AuthContext';
 import { hooks } from '@/config/queryClient';
+import {
+  NEXT_ITEM_NAV_BUTTON_ID,
+  PREVIOUS_ITEM_NAV_BUTTON_ID,
+} from '@/config/selectors';
 
 import {
   combineUuids,
@@ -32,7 +36,7 @@ function getNext(
   folderHierarchy: DiscriminatedItem[],
 ): DiscriminatedItem | null {
   const idx = folderHierarchy.findIndex(({ id }) => id === itemId);
-  if (idx < 0 || idx + 1 < folderHierarchy.length) {
+  if (idx < 0 || idx + 1 > folderHierarchy.length) {
     return null;
   }
   return folderHierarchy[idx + 1];
@@ -93,6 +97,7 @@ export function usePreviousNextButtons(): {
   return {
     previousButton: (
       <NavigationButton
+        id={PREVIOUS_ITEM_NAV_BUTTON_ID}
         disabled={!prev}
         key="previousButton"
         to="/player/$rootId/$itemId"
@@ -105,6 +110,7 @@ export function usePreviousNextButtons(): {
 
     nextButton: (
       <NavigationButton
+        id={NEXT_ITEM_NAV_BUTTON_ID}
         disabled={!next}
         key="nextButton"
         to="/player/$rootId/$itemId"

--- a/src/modules/player/navigationIsland/customButtons.tsx
+++ b/src/modules/player/navigationIsland/customButtons.tsx
@@ -19,10 +19,12 @@ const baseStyle = (theme: Theme) => ({
   '&:hover': {
     cursor: 'pointer',
   },
-  '&:disabled svg': {
+  // since not using `button` but `a` tags, they are not "disabled" in the css sense, so we use the disabled attribute
+  '&[disabled] svg': {
     color: 'gray',
   },
-  '&:disabled': {
+  // since not using `button` but `a` tags, they are not "disabled" in the css sense, so we use the disabled attribute
+  '&[disabled]': {
     backgroundColor: '#e9e9e9',
     cursor: 'not-allowed',
   },
@@ -44,7 +46,8 @@ export const ToolButton = styled('button')(({ theme }) => ({
   '& svg': {
     color: '#00639A',
   },
-  '&:hover:not(:disabled)': {
+  // since not using `button` but `a` tags, they are not "disabled" in the css sense, so we use the disabled attribute
+  '&:hover:not([disabled])': {
     backgroundColor: '#A2CEFF',
   },
 }));
@@ -55,16 +58,18 @@ const StyledNavigationButton = styled('a')(({ theme }) => ({
   '& svg': {
     color: theme.palette.primary.main,
   },
-  '&:hover:not(:disabled)': {
+  // since not using `button` but `a` tags, they are not "disabled" in the css sense, so we use the disabled attribute
+  '&:hover:not([disabled])': {
     backgroundColor: '#BFB4FF',
   },
 }));
 
-const StyledNavigationComponent = forwardRef<HTMLAnchorElement>(
-  (props, ref) => {
-    return <StyledNavigationButton ref={ref} {...props} />;
-  },
-);
+const StyledNavigationComponent = forwardRef<
+  HTMLAnchorElement,
+  { id?: string }
+>((props, ref) => {
+  return <StyledNavigationButton ref={ref} {...props} />;
+});
 
 const CreatedLinkComponent = createLink(StyledNavigationComponent);
 


### PR DESCRIPTION
In this PR I fix an issue with the navigation island in the player.

The value for the next button was always `null` because on a mistake on the boundary check (classic...).
So the buttons were not shown on the root, because both of them were null.
Inside the children, the next button did nothing. It was "disabled" but the styles were not applied correctly since we migrated from a `button` tag on an anchor `a` tag. Achors can not really be disabled in the semantical sens, instead tanstack router simply removes the href attribute. 
So we had to change the styles from `:disabled` (pseudo element disabled) to `[disabled]` (attribute disabled is present).

Also added a test to check that it works.

Thank you @pyphilia for noticing !

closes #797 
