### PR TITLE
fix: country selection

### DIFF
--- a/cypress/e2e/builder/map/map.cy.ts
+++ b/cypress/e2e/builder/map/map.cy.ts
@@ -7,7 +7,7 @@ import {
 import { MAP_ITEMS_PATH } from '../utils';
 
 describe('Map', () => {
-  it.skip('open create folder modal on Home', () => {
+  it('open create folder modal on Home', () => {
     cy.setUpApi();
     cy.visit(`${MAP_ITEMS_PATH}?enableGeolocation=false`);
 

--- a/cypress/e2e/builder/map/map.cy.ts
+++ b/cypress/e2e/builder/map/map.cy.ts
@@ -2,6 +2,7 @@
 import {
   CREATE_ITEM_FOLDER_ID,
   FOLDER_FORM_DESCRIPTION_ID,
+  MAP_COUNTRY_SELECTION_FORM_ID,
   buildMapViewId,
 } from '../../../../src/config/selectors';
 import { MAP_ITEMS_PATH } from '../utils';
@@ -15,13 +16,15 @@ describe('Map', () => {
     cy.get(`#${buildMapViewId()}`).should('be.visible');
 
     // select a country
-    cy.get(`#${buildMapViewId()} input`).click();
+    cy.get(
+      `#${buildMapViewId()} #${MAP_COUNTRY_SELECTION_FORM_ID} input`,
+    ).click();
     cy.get(`#${buildMapViewId()} [role="presentation"]`).click();
 
     // open location button
     cy.get(`#${buildMapViewId()}`).click();
-    cy.get(`#${buildMapViewId()} img[role="button"]`).click();
-    cy.get(`[data-testid="AddLocationAltIcon"]`).click();
+    cy.get(`#${buildMapViewId()} img[role="button"]`).click({ force: true });
+    cy.get(`[data-testid="AddLocationAltIcon"]`).click({ force: true });
 
     // open folder form
     cy.get(`#${CREATE_ITEM_FOLDER_ID}`).click();

--- a/src/config/selectors.ts
+++ b/src/config/selectors.ts
@@ -44,6 +44,8 @@ export const AVATAR_UPLOAD_ICON_ID = 'avatar-upload-icon';
 
 export const CROP_MODAL_CONFIRM_BUTTON_ID = 'crop-modal-confirm-button';
 
+export const MAP_COUNTRY_SELECTION_FORM_ID = 'map-country-selection-form';
+
 export const PERSONAL_INFO_EDIT_BUTTON_ID = 'personal-info-edit-button';
 export const PERSONAL_INFO_EDIT_CONTAINER_ID = 'personal-info-edit-container';
 export const PERSONAL_INFO_CANCEL_BUTTON_ID = 'personal-info-cancel-button';

--- a/src/modules/builder/map/components/CountryForm/CountryForm.tsx
+++ b/src/modules/builder/map/components/CountryForm/CountryForm.tsx
@@ -12,6 +12,7 @@ import frTrans from 'i18n-iso-countries/langs/fr.json';
 import itTrans from 'i18n-iso-countries/langs/it.json';
 
 import { NS } from '@/config/constants';
+import { MAP_COUNTRY_SELECTION_FORM_ID } from '@/config/selectors';
 
 import countries from '../../countries.json';
 import { Country } from '../../types';
@@ -67,7 +68,7 @@ const CountryForm = ({
     .sort((a, b) => a.name.localeCompare(b.name));
 
   return (
-    <div style={{ position: 'relative' }}>
+    <div id={MAP_COUNTRY_SELECTION_FORM_ID} style={{ position: 'relative' }}>
       <Autocomplete
         autoSelect
         onChange={handleOnChange as any}

--- a/src/modules/builder/map/components/Map.tsx
+++ b/src/modules/builder/map/components/Map.tsx
@@ -37,6 +37,7 @@ export function MapComponent({
   viewItemInBuilder,
 }: Readonly<Props>): JSX.Element {
   const [mapRef, setMapRef] = useState<Map | null>(null);
+  const [country, setCountry] = useState<Country | null>(null);
   const [tags, setTags] = useState<string[]>([]);
 
   const onChangeTags = (newTags: string[]) => {
@@ -44,6 +45,7 @@ export function MapComponent({
   };
   const onCountrySelection = (newValue: Country) => {
     if (mapRef) {
+      setCountry(newValue);
       mapRef.fitBounds([newValue.minBoundary, newValue.maxBoundary]);
     }
   };
@@ -125,7 +127,7 @@ export function MapComponent({
       >
         <ErrorBoundary fallback={<ErrorFallback />}>
           <LoggedOutWarning />
-          {!currentPosition && (
+          {!currentPosition && !country && (
             <CountryContent onCountrySelection={onCountrySelection} />
           )}
           <TopBar

--- a/src/modules/builder/map/components/Map.tsx
+++ b/src/modules/builder/map/components/Map.tsx
@@ -127,9 +127,11 @@ export function MapComponent({
       >
         <ErrorBoundary fallback={<ErrorFallback />}>
           <LoggedOutWarning />
-          {!currentPosition && !country && (
-            <CountryContent onCountrySelection={onCountrySelection} />
-          )}
+          {currentPosition
+            ? null
+            : !country && (
+                <CountryContent onCountrySelection={onCountrySelection} />
+              )}
           <TopBar
             tags={tags}
             onChange={onChangeTags}

--- a/src/modules/builder/map/components/map/CurrentMarkerPopupContent.tsx
+++ b/src/modules/builder/map/components/map/CurrentMarkerPopupContent.tsx
@@ -19,7 +19,7 @@ const CurrentMarkerPopupContent = ({
 }): JSX.Element => {
   const { t } = useTranslation(NS.Map);
   const { useAddressFromGeolocation, currentMember } = useQueryClientContext();
-  const { data: address, isLoading } = useAddressFromGeolocation(point, {
+  const { data: address, isPending } = useAddressFromGeolocation(point, {
     enabled: Boolean(currentMember) && open,
   });
 
@@ -28,7 +28,7 @@ const CurrentMarkerPopupContent = ({
       return address?.addressLabel;
     }
 
-    if (isLoading) {
+    if (isPending) {
       return <Skeleton />;
     }
 

--- a/src/routes/builder/_layout/index.tsx
+++ b/src/routes/builder/_layout/index.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react';
+import { type JSX } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Stack, useMediaQuery, useTheme } from '@mui/material';


### PR DESCRIPTION
close #774 

Country selection was always active because it only relied on the absence of currentGeolocation for the user. 
I added a state variable that disables the country selection after a successful first selection.
I also re-enabled the test.