### PR TITLE
fix: add missing env var for go links

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -53,6 +53,7 @@ jobs:
           VITE_RECAPTCHA_SITE_KEY: ${{ secrets.VITE_RECAPTCHA_SITE_KEY }}
           VITE_GRAASP_H5P_INTEGRATION_URL: ${{ vars.VITE_GRAASP_H5P_INTEGRATION_URL }}
           VITE_GOOGLE_KEY: ${{ secrets.VITE_GOOGLE_KEY }}
+          VITE_GRAASP_REDIRECTION_HOST: ${{ vars.VITE_GRAASP_REDIRECTION_HOST }}
         run: pnpm build
         shell: bash
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -55,10 +55,7 @@ jobs:
           VITE_VERSION: ${{ github.event.client_payload.tag || inputs.version }}
           VITE_GRAASP_DOMAIN: ${{ vars.VITE_GRAASP_DOMAIN }}
           VITE_GRAASP_API_HOST: ${{ vars.VITE_GRAASP_API_HOST }}
-          VITE_GRAASP_BUILDER_HOST: ${{ vars.VITE_GRAASP_BUILDER_HOST }}
-          VITE_GRAASP_PLAYER_HOST: ${{ vars.VITE_GRAASP_PLAYER_HOST }}
           VITE_GRAASP_LIBRARY_HOST: ${{ vars.VITE_GRAASP_LIBRARY_HOST }}
-          VITE_GRAASP_ANALYTICS_HOST: ${{ vars.VITE_GRAASP_ANALYZER_HOST }}
           VITE_SENTRY_ENV: ${{ vars.VITE_SENTRY_ENV }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           VITE_SHOW_NOTIFICATIONS: ${{ vars.VITE_SHOW_NOTIFICATIONS }}
@@ -67,6 +64,7 @@ jobs:
           VITE_RECAPTCHA_SITE_KEY: ${{ secrets.VITE_RECAPTCHA_SITE_KEY }}
           VITE_GRAASP_H5P_INTEGRATION_URL: ${{ vars.VITE_GRAASP_H5P_INTEGRATION_URL }}
           VITE_GOOGLE_KEY: ${{ secrets.VITE_GOOGLE_KEY }}
+          VITE_GRAASP_REDIRECTION_HOST: ${{ vars.VITE_GRAASP_REDIRECTION_HOST }}
         run: pnpm build
         shell: bash
 

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -55,10 +55,7 @@ jobs:
           VITE_VERSION: ${{ github.event.client_payload.tag || inputs.version }}
           VITE_GRAASP_DOMAIN: ${{ vars.VITE_GRAASP_DOMAIN }}
           VITE_GRAASP_API_HOST: ${{ vars.VITE_GRAASP_API_HOST }}
-          VITE_GRAASP_BUILDER_HOST: ${{ vars.VITE_GRAASP_BUILDER_HOST }}
-          VITE_GRAASP_PLAYER_HOST: ${{ vars.VITE_GRAASP_PLAYER_HOST }}
           VITE_GRAASP_LIBRARY_HOST: ${{ vars.VITE_GRAASP_LIBRARY_HOST }}
-          VITE_GRAASP_ANALYTICS_HOST: ${{ vars.VITE_GRAASP_ANALYZER_HOST }}
           VITE_SENTRY_ENV: ${{ vars.VITE_SENTRY_ENV }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           VITE_SHOW_NOTIFICATIONS: ${{ vars.VITE_SHOW_NOTIFICATIONS }}
@@ -67,6 +64,7 @@ jobs:
           VITE_RECAPTCHA_SITE_KEY: ${{ secrets.VITE_RECAPTCHA_SITE_KEY }}
           VITE_GRAASP_H5P_INTEGRATION_URL: ${{ vars.VITE_GRAASP_H5P_INTEGRATION_URL }}
           VITE_GOOGLE_KEY: ${{ secrets.VITE_GOOGLE_KEY }}
+          VITE_GRAASP_REDIRECTION_HOST: ${{ vars.VITE_GRAASP_REDIRECTION_HOST }}
         run: pnpm build
         shell: bash
 

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -48,6 +48,7 @@ jobs:
         env:
           VITE_GRAASP_H5P_INTEGRATION_URL: http://mock.value.com
           VITE_GOOGLE_KEY: 1234567890
+          VITE_GRAASP_REDIRECTION_HOST: http://go.mock.com
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
           VITE_RECAPTCHA_SITE_KEY: 123456789
           VITE_GOOGLE_KEY: 1234567890
           VITE_GRAASP_H5P_INTEGRATION_URL: http://integration.url/mock-value.html
+          VITE_GRAASP_REDIRECTION_HOST: http://go.mock.com
 
       - name: Get Latest playwright version
         run: echo "PLAYWRIGHT_VERSION=$(pnpm show playwright version)" >> $GITHUB_ENV

--- a/src/lib/ClientManager.ts
+++ b/src/lib/ClientManager.ts
@@ -72,7 +72,8 @@ export class ClientManager {
     itemId: string,
     qs: { [key: string]: string | number | boolean } = {},
   ) {
-    let host = this.host;
+    // make a copy of the host
+    let host = new URL(this.host.toString());
     if (context === Context.Library) {
       const libraryHost = this.clientHosts.get(context);
       if (libraryHost) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,7 @@ const config = ({ mode }: { mode: string }): UserConfig => {
   if (mode === 'production') {
     requireEnvVariable('VITE_GRAASP_H5P_INTEGRATION_URL');
     requireEnvVariable('VITE_GOOGLE_KEY');
+    requireEnvVariable('VITE_GRAASP_REDIRECTION_HOST');
   }
 
   // compute the port to use


### PR DESCRIPTION
Share page crashes if there are shortlinks set because a required env var is missing: `VITE_GRAASP_REDIRECTION_HOST`. 

Added a build time requirement for it and added it to all deployment envs.

close #809 