### PR TITLE
fix: add sentry session for Release Health reporting

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -87,9 +87,7 @@ export function AuthProvider({
   }, [currentMember]);
 
   const value = useMemo(() => {
-    Sentry.setUser(
-      currentMember ? { id: currentMember.id, name: currentMember.name } : null,
-    );
+    Sentry.setUser(currentMember ? { id: currentMember.id } : null);
     if (currentMember) {
       return {
         isAuthenticated: true as const,

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -10,6 +10,8 @@ import {
 
 import { AccountType, getCurrentAccountLang } from '@graasp/sdk';
 
+import * as Sentry from '@sentry/react';
+
 import { DEFAULT_LANG } from './config/constants';
 import { hooks, mutations } from './config/queryClient';
 import CustomInitialLoader from './ui/CustomInitialLoader/CustomInitialLoader';
@@ -55,7 +57,10 @@ export function AuthProvider({
 
   const logout = useCallback(async () => {
     const url = window.location.href;
+    // call the logout mutation
     await useLogout.mutateAsync();
+    // unset the user in Sentry session
+    Sentry.setUser(null);
     // redirect to auth page with url from the page that we just left.
     const redirectionURL = new URL('/auth/login', window.location.origin);
     redirectionURL.searchParams.set('url', url);
@@ -82,6 +87,9 @@ export function AuthProvider({
   }, [currentMember]);
 
   const value = useMemo(() => {
+    Sentry.setUser(
+      currentMember ? { id: currentMember.id, name: currentMember.name } : null,
+    );
     if (currentMember) {
       return {
         isAuthenticated: true as const,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -26,7 +26,6 @@ import { prefixer } from 'stylis';
 import '@/config/i18n';
 import { theme } from '@/ui/theme';
 
-import pkg from '../package.json';
 import { AuthProvider, useAuth } from './AuthContext';
 import './app.css';
 import {
@@ -48,7 +47,7 @@ SentryInit({
       maskAllInputs: true,
     }),
   ],
-  release: `${pkg.name}@${APP_VERSION}`,
+  release: APP_VERSION,
   environment: SENTRY_ENV,
   tracesSampleRate: 0.5,
 


### PR DESCRIPTION
In this PR I add the sentry release health feature by setting the current user when we know they are authenticated. This will help to track release adoption and health.
I only pass `id` and `name` as info to share the least possible.