### PR TITLE
fix: flicker caused by suspense when loading translations

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -25,4 +25,8 @@ i18n
       order: ['localStorage', 'navigator', 'querystring'],
       caches: ['localStorage'],
     },
+    react: {
+      // prevent the translations from using the react suspense and thus making the interface flicker
+      useSuspense: false,
+    },
   });

--- a/src/ui/PlatformSwitch/PlatformSwitch.stories.tsx
+++ b/src/ui/PlatformSwitch/PlatformSwitch.stories.tsx
@@ -11,19 +11,19 @@ import { Platform, PlatformType } from './hooks.js';
 const MOCK_PLATFORM_PROPS = {
   [Platform.Builder]: {
     tooltip: 'builder',
-    href: 'builder',
+    href: '/builder',
   },
   [Platform.Player]: {
     tooltip: 'player',
-    href: 'player',
+    href: '/player',
   },
   [Platform.Library]: {
     tooltip: 'library',
-    href: 'library',
+    href: '/library',
   },
   [Platform.Analytics]: {
     tooltip: 'analytics',
-    href: 'analytics',
+    href: '/analytics',
   },
 };
 

--- a/src/ui/PlatformSwitch/PlatformSwitch.tsx
+++ b/src/ui/PlatformSwitch/PlatformSwitch.tsx
@@ -12,6 +12,8 @@ import {
   useTheme,
 } from '@mui/material';
 
+import { Link } from '@tanstack/react-router';
+
 import AnalyticsIcon from '../icons/AnalyticsIcon.js';
 import BuildIcon from '../icons/BuildIcon.js';
 import LibraryIcon from '../icons/LibraryIcon.js';
@@ -126,14 +128,14 @@ export const PlatformSwitch = ({
         title={platformProps?.disabled ? undefined : tooltip}
         placement={platformProps?.placement}
       >
-        <a
+        <Link
           id={platformProps?.id}
           style={{
             display: 'flex',
             cursor: platformProps?.disabled ? 'default' : 'pointer',
           }}
           data-testid={platform}
-          href={!platformProps?.disabled ? platformProps?.href : undefined}
+          to={!platformProps?.disabled ? platformProps?.href : undefined}
           aria-disabled={platformProps?.disabled}
           // data-umami-event={`header-navigation-switch-${platform}`}
         >
@@ -148,7 +150,7 @@ export const PlatformSwitch = ({
             sx={sxProps}
             disableHover={false}
           />
-        </a>
+        </Link>
       </Tooltip>
     );
   };


### PR DESCRIPTION
While trying to fix the tests in #803 I had some weird test failures caused by what looked liked re-renders.

When investigting what could possibly cause these re-renders (when clicking to change the item type in the add new item modal), I saw that the translation file for the `messages` namespace was being loaded. 

Coupled with this insight I set on looking why loading new translations might cause a full page reload ... and I found https://stackoverflow.com/questions/68455594/page-flickers-when-lazy-loading-translations-with-i18next-http-backend

And indeed, adding the `{react: { useSuspense: false } }` setting in the i18n config solved the issue. 

I also changed the PlatformSwitch buttons to be TSR links instead of dumb anchor tags, which removes the flickering when navigating between account and builder using the navigation switch. Neat !

Pfiou finally found the reason behind the flickering issues. 💪 