### PR TITLE
fix: sidebar open state issue

### DIFF
--- a/src/routes/player/$rootId/$itemId.tsx
+++ b/src/routes/player/$rootId/$itemId.tsx
@@ -84,7 +84,7 @@ function PlayerWrapper(): JSX.Element {
          * override the open prop to close the menu when there is no rootId or we could not fetch the item (logged out and not public)
          * we want to keep the default behavior when the user is logged in
          */
-        Boolean(rootId)
+        Boolean(rootId) && Boolean(item) ? undefined : false
       }
       context={Context.Player}
       drawerContent={<ItemNavigation />}


### PR DESCRIPTION
In this PR:
- fix an issue with the player drawer showing when user is logged out
- fix an issue with the player drawer being open when on mobile

The drawer should be closed when:
- there is not rootId
- the user does not have access to the item (user is not logged in for pseudo and private item and item is not public)
- user is logged in but uses mobile

The drawer should be open in all other cases.

We had an issue where the mobile behaviour was not correct, because we were always setting the `open` prop to a defined value. We need to "release" the prop so the default behaviour can be used.

The second issue was that the item was never fetched since the hook call was wrong. Now we can use the fact that the item data was fetched to know if the user has access and if they have access we display the side bar. 