### PR TITLE
feat: add settings in member drop down

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -59,5 +59,11 @@
     "BOOKMARKED_ITEMS": "Bookmarks",
     "PUBLISHED_ITEMS": "Published Items",
     "TRASH": "Trash"
+  },
+  "USER_SWITCH": {
+    "PROFILE": "Profile",
+    "SETTINGS": "Settings",
+    "STORAGE": "Storage",
+    "SIGN_IN": "Sign In"
   }
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as SigninImport } from './routes/signin'
 import { Route as BuilderImport } from './routes/builder'
 import { Route as AuthImport } from './routes/auth'
 import { Route as AnalyticsImport } from './routes/analytics'
+import { Route as MemberOnlyImport } from './routes/_memberOnly'
 import { Route as LandingImport } from './routes/_landing'
 import { Route as PlayerIndexImport } from './routes/player/index'
 import { Route as AnalyticsIndexImport } from './routes/analytics/index'
@@ -28,6 +29,7 @@ import { Route as AuthResetPasswordImport } from './routes/auth/reset-password'
 import { Route as AuthRegisterImport } from './routes/auth/register'
 import { Route as AuthLoginImport } from './routes/auth/login'
 import { Route as AuthForgotPasswordImport } from './routes/auth/forgot-password'
+import { Route as MemberOnlyHomeImport } from './routes/_memberOnly/home'
 import { Route as LandingTermsImport } from './routes/_landing/terms'
 import { Route as LandingSupportImport } from './routes/_landing/support'
 import { Route as LandingPolicyImport } from './routes/_landing/policy'
@@ -43,6 +45,9 @@ import { Route as BuilderLayoutRecycledImport } from './routes/builder/_layout/r
 import { Route as BuilderLayoutPublishedImport } from './routes/builder/_layout/published'
 import { Route as BuilderLayoutBookmarksImport } from './routes/builder/_layout/bookmarks'
 import { Route as AnalyticsItemsItemIdImport } from './routes/analytics/items/$itemId'
+import { Route as MemberOnlyAccountStorageImport } from './routes/_memberOnly/account/storage'
+import { Route as MemberOnlyAccountStatsImport } from './routes/_memberOnly/account/stats'
+import { Route as MemberOnlyAccountSettingsImport } from './routes/_memberOnly/account/settings'
 import { Route as PlayerRootIdItemIdIndexImport } from './routes/player/$rootId/$itemId/index'
 import { Route as BuilderItemsItemIdIndexImport } from './routes/builder/items/$itemId/index'
 import { Route as AnalyticsItemsItemIdIndexImport } from './routes/analytics/items/$itemId/index'
@@ -79,6 +84,11 @@ const AuthRoute = AuthImport.update({
 const AnalyticsRoute = AnalyticsImport.update({
   id: '/analytics',
   path: '/analytics',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const MemberOnlyRoute = MemberOnlyImport.update({
+  id: '/_memberOnly',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -156,6 +166,12 @@ const AuthForgotPasswordRoute = AuthForgotPasswordImport.update({
   id: '/forgot-password',
   path: '/forgot-password',
   getParentRoute: () => AuthRoute,
+} as any)
+
+const MemberOnlyHomeRoute = MemberOnlyHomeImport.update({
+  id: '/home',
+  path: '/home',
+  getParentRoute: () => MemberOnlyRoute,
 } as any)
 
 const LandingTermsRoute = LandingTermsImport.update({
@@ -248,6 +264,24 @@ const AnalyticsItemsItemIdRoute = AnalyticsItemsItemIdImport.update({
   getParentRoute: () => AnalyticsRoute,
 } as any)
 
+const MemberOnlyAccountStorageRoute = MemberOnlyAccountStorageImport.update({
+  id: '/account/storage',
+  path: '/account/storage',
+  getParentRoute: () => MemberOnlyRoute,
+} as any)
+
+const MemberOnlyAccountStatsRoute = MemberOnlyAccountStatsImport.update({
+  id: '/account/stats',
+  path: '/account/stats',
+  getParentRoute: () => MemberOnlyRoute,
+} as any)
+
+const MemberOnlyAccountSettingsRoute = MemberOnlyAccountSettingsImport.update({
+  id: '/account/settings',
+  path: '/account/settings',
+  getParentRoute: () => MemberOnlyRoute,
+} as any)
+
 const PlayerRootIdItemIdIndexRoute = PlayerRootIdItemIdIndexImport.update({
   id: '/',
   path: '/',
@@ -338,6 +372,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LandingImport
       parentRoute: typeof rootRoute
     }
+    '/_memberOnly': {
+      id: '/_memberOnly'
+      path: ''
+      fullPath: ''
+      preLoaderRoute: typeof MemberOnlyImport
+      parentRoute: typeof rootRoute
+    }
     '/analytics': {
       id: '/analytics'
       path: '/analytics'
@@ -414,6 +455,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/terms'
       preLoaderRoute: typeof LandingTermsImport
       parentRoute: typeof LandingImport
+    }
+    '/_memberOnly/home': {
+      id: '/_memberOnly/home'
+      path: '/home'
+      fullPath: '/home'
+      preLoaderRoute: typeof MemberOnlyHomeImport
+      parentRoute: typeof MemberOnlyImport
     }
     '/auth/forgot-password': {
       id: '/auth/forgot-password'
@@ -498,6 +546,27 @@ declare module '@tanstack/react-router' {
       fullPath: '/player'
       preLoaderRoute: typeof PlayerIndexImport
       parentRoute: typeof rootRoute
+    }
+    '/_memberOnly/account/settings': {
+      id: '/_memberOnly/account/settings'
+      path: '/account/settings'
+      fullPath: '/account/settings'
+      preLoaderRoute: typeof MemberOnlyAccountSettingsImport
+      parentRoute: typeof MemberOnlyImport
+    }
+    '/_memberOnly/account/stats': {
+      id: '/_memberOnly/account/stats'
+      path: '/account/stats'
+      fullPath: '/account/stats'
+      preLoaderRoute: typeof MemberOnlyAccountStatsImport
+      parentRoute: typeof MemberOnlyImport
+    }
+    '/_memberOnly/account/storage': {
+      id: '/_memberOnly/account/storage'
+      path: '/account/storage'
+      fullPath: '/account/storage'
+      preLoaderRoute: typeof MemberOnlyAccountStorageImport
+      parentRoute: typeof MemberOnlyImport
     }
     '/analytics/items/$itemId': {
       id: '/analytics/items/$itemId'
@@ -669,6 +738,24 @@ const LandingRouteChildren: LandingRouteChildren = {
 const LandingRouteWithChildren =
   LandingRoute._addFileChildren(LandingRouteChildren)
 
+interface MemberOnlyRouteChildren {
+  MemberOnlyHomeRoute: typeof MemberOnlyHomeRoute
+  MemberOnlyAccountSettingsRoute: typeof MemberOnlyAccountSettingsRoute
+  MemberOnlyAccountStatsRoute: typeof MemberOnlyAccountStatsRoute
+  MemberOnlyAccountStorageRoute: typeof MemberOnlyAccountStorageRoute
+}
+
+const MemberOnlyRouteChildren: MemberOnlyRouteChildren = {
+  MemberOnlyHomeRoute: MemberOnlyHomeRoute,
+  MemberOnlyAccountSettingsRoute: MemberOnlyAccountSettingsRoute,
+  MemberOnlyAccountStatsRoute: MemberOnlyAccountStatsRoute,
+  MemberOnlyAccountStorageRoute: MemberOnlyAccountStorageRoute,
+}
+
+const MemberOnlyRouteWithChildren = MemberOnlyRoute._addFileChildren(
+  MemberOnlyRouteChildren,
+)
+
 interface AnalyticsItemsItemIdRouteChildren {
   AnalyticsItemsItemIdAppsRoute: typeof AnalyticsItemsItemIdAppsRoute
   AnalyticsItemsItemIdExportRoute: typeof AnalyticsItemsItemIdExportRoute
@@ -802,7 +889,7 @@ const PlayerRootIdItemIdRouteWithChildren =
   PlayerRootIdItemIdRoute._addFileChildren(PlayerRootIdItemIdRouteChildren)
 
 export interface FileRoutesByFullPath {
-  '': typeof LandingRouteWithChildren
+  '': typeof MemberOnlyRouteWithChildren
   '/analytics': typeof AnalyticsRouteWithChildren
   '/auth': typeof AuthRouteWithChildren
   '/builder': typeof BuilderLayoutRouteWithChildren
@@ -814,6 +901,7 @@ export interface FileRoutesByFullPath {
   '/policy': typeof LandingPolicyRoute
   '/support': typeof LandingSupportRoute
   '/terms': typeof LandingTermsRoute
+  '/home': typeof MemberOnlyHomeRoute
   '/auth/forgot-password': typeof AuthForgotPasswordRoute
   '/auth/login': typeof AuthLoginRoute
   '/auth/register': typeof AuthRegisterRoute
@@ -825,6 +913,9 @@ export interface FileRoutesByFullPath {
   '/': typeof LandingIndexRoute
   '/analytics/': typeof AnalyticsIndexRoute
   '/player': typeof PlayerIndexRoute
+  '/account/settings': typeof MemberOnlyAccountSettingsRoute
+  '/account/stats': typeof MemberOnlyAccountStatsRoute
+  '/account/storage': typeof MemberOnlyAccountStorageRoute
   '/analytics/items/$itemId': typeof AnalyticsItemsItemIdRouteWithChildren
   '/builder/bookmarks': typeof BuilderLayoutBookmarksRoute
   '/builder/published': typeof BuilderLayoutPublishedRoute
@@ -847,6 +938,7 @@ export interface FileRoutesByFullPath {
 }
 
 export interface FileRoutesByTo {
+  '': typeof MemberOnlyRouteWithChildren
   '/auth': typeof AuthRouteWithChildren
   '/builder': typeof BuilderLayoutIndexRoute
   '/signin': typeof SigninRoute
@@ -857,6 +949,7 @@ export interface FileRoutesByTo {
   '/policy': typeof LandingPolicyRoute
   '/support': typeof LandingSupportRoute
   '/terms': typeof LandingTermsRoute
+  '/home': typeof MemberOnlyHomeRoute
   '/auth/forgot-password': typeof AuthForgotPasswordRoute
   '/auth/login': typeof AuthLoginRoute
   '/auth/register': typeof AuthRegisterRoute
@@ -868,6 +961,9 @@ export interface FileRoutesByTo {
   '/': typeof LandingIndexRoute
   '/analytics': typeof AnalyticsIndexRoute
   '/player': typeof PlayerIndexRoute
+  '/account/settings': typeof MemberOnlyAccountSettingsRoute
+  '/account/stats': typeof MemberOnlyAccountStatsRoute
+  '/account/storage': typeof MemberOnlyAccountStorageRoute
   '/builder/bookmarks': typeof BuilderLayoutBookmarksRoute
   '/builder/published': typeof BuilderLayoutPublishedRoute
   '/builder/recycled': typeof BuilderLayoutRecycledRoute
@@ -888,6 +984,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRoute
   '/_landing': typeof LandingRouteWithChildren
+  '/_memberOnly': typeof MemberOnlyRouteWithChildren
   '/analytics': typeof AnalyticsRouteWithChildren
   '/auth': typeof AuthRouteWithChildren
   '/builder': typeof BuilderRouteWithChildren
@@ -899,6 +996,7 @@ export interface FileRoutesById {
   '/_landing/policy': typeof LandingPolicyRoute
   '/_landing/support': typeof LandingSupportRoute
   '/_landing/terms': typeof LandingTermsRoute
+  '/_memberOnly/home': typeof MemberOnlyHomeRoute
   '/auth/forgot-password': typeof AuthForgotPasswordRoute
   '/auth/login': typeof AuthLoginRoute
   '/auth/register': typeof AuthRegisterRoute
@@ -911,6 +1009,9 @@ export interface FileRoutesById {
   '/_landing/': typeof LandingIndexRoute
   '/analytics/': typeof AnalyticsIndexRoute
   '/player/': typeof PlayerIndexRoute
+  '/_memberOnly/account/settings': typeof MemberOnlyAccountSettingsRoute
+  '/_memberOnly/account/stats': typeof MemberOnlyAccountStatsRoute
+  '/_memberOnly/account/storage': typeof MemberOnlyAccountStorageRoute
   '/analytics/items/$itemId': typeof AnalyticsItemsItemIdRouteWithChildren
   '/builder/_layout/bookmarks': typeof BuilderLayoutBookmarksRoute
   '/builder/_layout/published': typeof BuilderLayoutPublishedRoute
@@ -948,6 +1049,7 @@ export interface FileRouteTypes {
     | '/policy'
     | '/support'
     | '/terms'
+    | '/home'
     | '/auth/forgot-password'
     | '/auth/login'
     | '/auth/register'
@@ -959,6 +1061,9 @@ export interface FileRouteTypes {
     | '/'
     | '/analytics/'
     | '/player'
+    | '/account/settings'
+    | '/account/stats'
+    | '/account/storage'
     | '/analytics/items/$itemId'
     | '/builder/bookmarks'
     | '/builder/published'
@@ -980,6 +1085,7 @@ export interface FileRouteTypes {
     | '/builder/items/$itemId/share'
   fileRoutesByTo: FileRoutesByTo
   to:
+    | ''
     | '/auth'
     | '/builder'
     | '/signin'
@@ -990,6 +1096,7 @@ export interface FileRouteTypes {
     | '/policy'
     | '/support'
     | '/terms'
+    | '/home'
     | '/auth/forgot-password'
     | '/auth/login'
     | '/auth/register'
@@ -1001,6 +1108,9 @@ export interface FileRouteTypes {
     | '/'
     | '/analytics'
     | '/player'
+    | '/account/settings'
+    | '/account/stats'
+    | '/account/storage'
     | '/builder/bookmarks'
     | '/builder/published'
     | '/builder/recycled'
@@ -1019,6 +1129,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/_landing'
+    | '/_memberOnly'
     | '/analytics'
     | '/auth'
     | '/builder'
@@ -1030,6 +1141,7 @@ export interface FileRouteTypes {
     | '/_landing/policy'
     | '/_landing/support'
     | '/_landing/terms'
+    | '/_memberOnly/home'
     | '/auth/forgot-password'
     | '/auth/login'
     | '/auth/register'
@@ -1042,6 +1154,9 @@ export interface FileRouteTypes {
     | '/_landing/'
     | '/analytics/'
     | '/player/'
+    | '/_memberOnly/account/settings'
+    | '/_memberOnly/account/stats'
+    | '/_memberOnly/account/storage'
     | '/analytics/items/$itemId'
     | '/builder/_layout/bookmarks'
     | '/builder/_layout/published'
@@ -1067,6 +1182,7 @@ export interface FileRouteTypes {
 
 export interface RootRouteChildren {
   LandingRoute: typeof LandingRouteWithChildren
+  MemberOnlyRoute: typeof MemberOnlyRouteWithChildren
   AnalyticsRoute: typeof AnalyticsRouteWithChildren
   AuthRoute: typeof AuthRouteWithChildren
   BuilderRoute: typeof BuilderRouteWithChildren
@@ -1079,6 +1195,7 @@ export interface RootRouteChildren {
 
 const rootRouteChildren: RootRouteChildren = {
   LandingRoute: LandingRouteWithChildren,
+  MemberOnlyRoute: MemberOnlyRouteWithChildren,
   AnalyticsRoute: AnalyticsRouteWithChildren,
   AuthRoute: AuthRouteWithChildren,
   BuilderRoute: BuilderRouteWithChildren,
@@ -1100,6 +1217,7 @@ export const routeTree = rootRoute
       "filePath": "__root.tsx",
       "children": [
         "/_landing",
+        "/_memberOnly",
         "/analytics",
         "/auth",
         "/builder",
@@ -1121,6 +1239,15 @@ export const routeTree = rootRoute
         "/_landing/support",
         "/_landing/terms",
         "/_landing/"
+      ]
+    },
+    "/_memberOnly": {
+      "filePath": "_memberOnly.tsx",
+      "children": [
+        "/_memberOnly/home",
+        "/_memberOnly/account/settings",
+        "/_memberOnly/account/stats",
+        "/_memberOnly/account/storage"
       ]
     },
     "/analytics": {
@@ -1180,6 +1307,10 @@ export const routeTree = rootRoute
       "filePath": "_landing/terms.tsx",
       "parent": "/_landing"
     },
+    "/_memberOnly/home": {
+      "filePath": "_memberOnly/home.tsx",
+      "parent": "/_memberOnly"
+    },
     "/auth/forgot-password": {
       "filePath": "auth/forgot-password.tsx",
       "parent": "/auth"
@@ -1231,6 +1362,18 @@ export const routeTree = rootRoute
     },
     "/player/": {
       "filePath": "player/index.tsx"
+    },
+    "/_memberOnly/account/settings": {
+      "filePath": "_memberOnly/account/settings.tsx",
+      "parent": "/_memberOnly"
+    },
+    "/_memberOnly/account/stats": {
+      "filePath": "_memberOnly/account/stats.tsx",
+      "parent": "/_memberOnly"
+    },
+    "/_memberOnly/account/storage": {
+      "filePath": "_memberOnly/account/storage.tsx",
+      "parent": "/_memberOnly"
     },
     "/analytics/items/$itemId": {
       "filePath": "analytics/items/$itemId.tsx",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,7 +15,6 @@ import { Route as SigninImport } from './routes/signin'
 import { Route as BuilderImport } from './routes/builder'
 import { Route as AuthImport } from './routes/auth'
 import { Route as AnalyticsImport } from './routes/analytics'
-import { Route as MemberOnlyImport } from './routes/_memberOnly'
 import { Route as LandingImport } from './routes/_landing'
 import { Route as PlayerIndexImport } from './routes/player/index'
 import { Route as AnalyticsIndexImport } from './routes/analytics/index'
@@ -29,7 +28,6 @@ import { Route as AuthResetPasswordImport } from './routes/auth/reset-password'
 import { Route as AuthRegisterImport } from './routes/auth/register'
 import { Route as AuthLoginImport } from './routes/auth/login'
 import { Route as AuthForgotPasswordImport } from './routes/auth/forgot-password'
-import { Route as MemberOnlyHomeImport } from './routes/_memberOnly/home'
 import { Route as LandingTermsImport } from './routes/_landing/terms'
 import { Route as LandingSupportImport } from './routes/_landing/support'
 import { Route as LandingPolicyImport } from './routes/_landing/policy'
@@ -45,9 +43,6 @@ import { Route as BuilderLayoutRecycledImport } from './routes/builder/_layout/r
 import { Route as BuilderLayoutPublishedImport } from './routes/builder/_layout/published'
 import { Route as BuilderLayoutBookmarksImport } from './routes/builder/_layout/bookmarks'
 import { Route as AnalyticsItemsItemIdImport } from './routes/analytics/items/$itemId'
-import { Route as MemberOnlyAccountStorageImport } from './routes/_memberOnly/account/storage'
-import { Route as MemberOnlyAccountStatsImport } from './routes/_memberOnly/account/stats'
-import { Route as MemberOnlyAccountSettingsImport } from './routes/_memberOnly/account/settings'
 import { Route as PlayerRootIdItemIdIndexImport } from './routes/player/$rootId/$itemId/index'
 import { Route as BuilderItemsItemIdIndexImport } from './routes/builder/items/$itemId/index'
 import { Route as AnalyticsItemsItemIdIndexImport } from './routes/analytics/items/$itemId/index'
@@ -84,11 +79,6 @@ const AuthRoute = AuthImport.update({
 const AnalyticsRoute = AnalyticsImport.update({
   id: '/analytics',
   path: '/analytics',
-  getParentRoute: () => rootRoute,
-} as any)
-
-const MemberOnlyRoute = MemberOnlyImport.update({
-  id: '/_memberOnly',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -166,12 +156,6 @@ const AuthForgotPasswordRoute = AuthForgotPasswordImport.update({
   id: '/forgot-password',
   path: '/forgot-password',
   getParentRoute: () => AuthRoute,
-} as any)
-
-const MemberOnlyHomeRoute = MemberOnlyHomeImport.update({
-  id: '/home',
-  path: '/home',
-  getParentRoute: () => MemberOnlyRoute,
 } as any)
 
 const LandingTermsRoute = LandingTermsImport.update({
@@ -264,24 +248,6 @@ const AnalyticsItemsItemIdRoute = AnalyticsItemsItemIdImport.update({
   getParentRoute: () => AnalyticsRoute,
 } as any)
 
-const MemberOnlyAccountStorageRoute = MemberOnlyAccountStorageImport.update({
-  id: '/account/storage',
-  path: '/account/storage',
-  getParentRoute: () => MemberOnlyRoute,
-} as any)
-
-const MemberOnlyAccountStatsRoute = MemberOnlyAccountStatsImport.update({
-  id: '/account/stats',
-  path: '/account/stats',
-  getParentRoute: () => MemberOnlyRoute,
-} as any)
-
-const MemberOnlyAccountSettingsRoute = MemberOnlyAccountSettingsImport.update({
-  id: '/account/settings',
-  path: '/account/settings',
-  getParentRoute: () => MemberOnlyRoute,
-} as any)
-
 const PlayerRootIdItemIdIndexRoute = PlayerRootIdItemIdIndexImport.update({
   id: '/',
   path: '/',
@@ -372,13 +338,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LandingImport
       parentRoute: typeof rootRoute
     }
-    '/_memberOnly': {
-      id: '/_memberOnly'
-      path: ''
-      fullPath: ''
-      preLoaderRoute: typeof MemberOnlyImport
-      parentRoute: typeof rootRoute
-    }
     '/analytics': {
       id: '/analytics'
       path: '/analytics'
@@ -455,13 +414,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/terms'
       preLoaderRoute: typeof LandingTermsImport
       parentRoute: typeof LandingImport
-    }
-    '/_memberOnly/home': {
-      id: '/_memberOnly/home'
-      path: '/home'
-      fullPath: '/home'
-      preLoaderRoute: typeof MemberOnlyHomeImport
-      parentRoute: typeof MemberOnlyImport
     }
     '/auth/forgot-password': {
       id: '/auth/forgot-password'
@@ -546,27 +498,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/player'
       preLoaderRoute: typeof PlayerIndexImport
       parentRoute: typeof rootRoute
-    }
-    '/_memberOnly/account/settings': {
-      id: '/_memberOnly/account/settings'
-      path: '/account/settings'
-      fullPath: '/account/settings'
-      preLoaderRoute: typeof MemberOnlyAccountSettingsImport
-      parentRoute: typeof MemberOnlyImport
-    }
-    '/_memberOnly/account/stats': {
-      id: '/_memberOnly/account/stats'
-      path: '/account/stats'
-      fullPath: '/account/stats'
-      preLoaderRoute: typeof MemberOnlyAccountStatsImport
-      parentRoute: typeof MemberOnlyImport
-    }
-    '/_memberOnly/account/storage': {
-      id: '/_memberOnly/account/storage'
-      path: '/account/storage'
-      fullPath: '/account/storage'
-      preLoaderRoute: typeof MemberOnlyAccountStorageImport
-      parentRoute: typeof MemberOnlyImport
     }
     '/analytics/items/$itemId': {
       id: '/analytics/items/$itemId'
@@ -738,24 +669,6 @@ const LandingRouteChildren: LandingRouteChildren = {
 const LandingRouteWithChildren =
   LandingRoute._addFileChildren(LandingRouteChildren)
 
-interface MemberOnlyRouteChildren {
-  MemberOnlyHomeRoute: typeof MemberOnlyHomeRoute
-  MemberOnlyAccountSettingsRoute: typeof MemberOnlyAccountSettingsRoute
-  MemberOnlyAccountStatsRoute: typeof MemberOnlyAccountStatsRoute
-  MemberOnlyAccountStorageRoute: typeof MemberOnlyAccountStorageRoute
-}
-
-const MemberOnlyRouteChildren: MemberOnlyRouteChildren = {
-  MemberOnlyHomeRoute: MemberOnlyHomeRoute,
-  MemberOnlyAccountSettingsRoute: MemberOnlyAccountSettingsRoute,
-  MemberOnlyAccountStatsRoute: MemberOnlyAccountStatsRoute,
-  MemberOnlyAccountStorageRoute: MemberOnlyAccountStorageRoute,
-}
-
-const MemberOnlyRouteWithChildren = MemberOnlyRoute._addFileChildren(
-  MemberOnlyRouteChildren,
-)
-
 interface AnalyticsItemsItemIdRouteChildren {
   AnalyticsItemsItemIdAppsRoute: typeof AnalyticsItemsItemIdAppsRoute
   AnalyticsItemsItemIdExportRoute: typeof AnalyticsItemsItemIdExportRoute
@@ -889,7 +802,7 @@ const PlayerRootIdItemIdRouteWithChildren =
   PlayerRootIdItemIdRoute._addFileChildren(PlayerRootIdItemIdRouteChildren)
 
 export interface FileRoutesByFullPath {
-  '': typeof MemberOnlyRouteWithChildren
+  '': typeof LandingRouteWithChildren
   '/analytics': typeof AnalyticsRouteWithChildren
   '/auth': typeof AuthRouteWithChildren
   '/builder': typeof BuilderLayoutRouteWithChildren
@@ -901,7 +814,6 @@ export interface FileRoutesByFullPath {
   '/policy': typeof LandingPolicyRoute
   '/support': typeof LandingSupportRoute
   '/terms': typeof LandingTermsRoute
-  '/home': typeof MemberOnlyHomeRoute
   '/auth/forgot-password': typeof AuthForgotPasswordRoute
   '/auth/login': typeof AuthLoginRoute
   '/auth/register': typeof AuthRegisterRoute
@@ -913,9 +825,6 @@ export interface FileRoutesByFullPath {
   '/': typeof LandingIndexRoute
   '/analytics/': typeof AnalyticsIndexRoute
   '/player': typeof PlayerIndexRoute
-  '/account/settings': typeof MemberOnlyAccountSettingsRoute
-  '/account/stats': typeof MemberOnlyAccountStatsRoute
-  '/account/storage': typeof MemberOnlyAccountStorageRoute
   '/analytics/items/$itemId': typeof AnalyticsItemsItemIdRouteWithChildren
   '/builder/bookmarks': typeof BuilderLayoutBookmarksRoute
   '/builder/published': typeof BuilderLayoutPublishedRoute
@@ -938,7 +847,6 @@ export interface FileRoutesByFullPath {
 }
 
 export interface FileRoutesByTo {
-  '': typeof MemberOnlyRouteWithChildren
   '/auth': typeof AuthRouteWithChildren
   '/builder': typeof BuilderLayoutIndexRoute
   '/signin': typeof SigninRoute
@@ -949,7 +857,6 @@ export interface FileRoutesByTo {
   '/policy': typeof LandingPolicyRoute
   '/support': typeof LandingSupportRoute
   '/terms': typeof LandingTermsRoute
-  '/home': typeof MemberOnlyHomeRoute
   '/auth/forgot-password': typeof AuthForgotPasswordRoute
   '/auth/login': typeof AuthLoginRoute
   '/auth/register': typeof AuthRegisterRoute
@@ -961,9 +868,6 @@ export interface FileRoutesByTo {
   '/': typeof LandingIndexRoute
   '/analytics': typeof AnalyticsIndexRoute
   '/player': typeof PlayerIndexRoute
-  '/account/settings': typeof MemberOnlyAccountSettingsRoute
-  '/account/stats': typeof MemberOnlyAccountStatsRoute
-  '/account/storage': typeof MemberOnlyAccountStorageRoute
   '/builder/bookmarks': typeof BuilderLayoutBookmarksRoute
   '/builder/published': typeof BuilderLayoutPublishedRoute
   '/builder/recycled': typeof BuilderLayoutRecycledRoute
@@ -984,7 +888,6 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRoute
   '/_landing': typeof LandingRouteWithChildren
-  '/_memberOnly': typeof MemberOnlyRouteWithChildren
   '/analytics': typeof AnalyticsRouteWithChildren
   '/auth': typeof AuthRouteWithChildren
   '/builder': typeof BuilderRouteWithChildren
@@ -996,7 +899,6 @@ export interface FileRoutesById {
   '/_landing/policy': typeof LandingPolicyRoute
   '/_landing/support': typeof LandingSupportRoute
   '/_landing/terms': typeof LandingTermsRoute
-  '/_memberOnly/home': typeof MemberOnlyHomeRoute
   '/auth/forgot-password': typeof AuthForgotPasswordRoute
   '/auth/login': typeof AuthLoginRoute
   '/auth/register': typeof AuthRegisterRoute
@@ -1009,9 +911,6 @@ export interface FileRoutesById {
   '/_landing/': typeof LandingIndexRoute
   '/analytics/': typeof AnalyticsIndexRoute
   '/player/': typeof PlayerIndexRoute
-  '/_memberOnly/account/settings': typeof MemberOnlyAccountSettingsRoute
-  '/_memberOnly/account/stats': typeof MemberOnlyAccountStatsRoute
-  '/_memberOnly/account/storage': typeof MemberOnlyAccountStorageRoute
   '/analytics/items/$itemId': typeof AnalyticsItemsItemIdRouteWithChildren
   '/builder/_layout/bookmarks': typeof BuilderLayoutBookmarksRoute
   '/builder/_layout/published': typeof BuilderLayoutPublishedRoute
@@ -1049,7 +948,6 @@ export interface FileRouteTypes {
     | '/policy'
     | '/support'
     | '/terms'
-    | '/home'
     | '/auth/forgot-password'
     | '/auth/login'
     | '/auth/register'
@@ -1061,9 +959,6 @@ export interface FileRouteTypes {
     | '/'
     | '/analytics/'
     | '/player'
-    | '/account/settings'
-    | '/account/stats'
-    | '/account/storage'
     | '/analytics/items/$itemId'
     | '/builder/bookmarks'
     | '/builder/published'
@@ -1085,7 +980,6 @@ export interface FileRouteTypes {
     | '/builder/items/$itemId/share'
   fileRoutesByTo: FileRoutesByTo
   to:
-    | ''
     | '/auth'
     | '/builder'
     | '/signin'
@@ -1096,7 +990,6 @@ export interface FileRouteTypes {
     | '/policy'
     | '/support'
     | '/terms'
-    | '/home'
     | '/auth/forgot-password'
     | '/auth/login'
     | '/auth/register'
@@ -1108,9 +1001,6 @@ export interface FileRouteTypes {
     | '/'
     | '/analytics'
     | '/player'
-    | '/account/settings'
-    | '/account/stats'
-    | '/account/storage'
     | '/builder/bookmarks'
     | '/builder/published'
     | '/builder/recycled'
@@ -1129,7 +1019,6 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/_landing'
-    | '/_memberOnly'
     | '/analytics'
     | '/auth'
     | '/builder'
@@ -1141,7 +1030,6 @@ export interface FileRouteTypes {
     | '/_landing/policy'
     | '/_landing/support'
     | '/_landing/terms'
-    | '/_memberOnly/home'
     | '/auth/forgot-password'
     | '/auth/login'
     | '/auth/register'
@@ -1154,9 +1042,6 @@ export interface FileRouteTypes {
     | '/_landing/'
     | '/analytics/'
     | '/player/'
-    | '/_memberOnly/account/settings'
-    | '/_memberOnly/account/stats'
-    | '/_memberOnly/account/storage'
     | '/analytics/items/$itemId'
     | '/builder/_layout/bookmarks'
     | '/builder/_layout/published'
@@ -1182,7 +1067,6 @@ export interface FileRouteTypes {
 
 export interface RootRouteChildren {
   LandingRoute: typeof LandingRouteWithChildren
-  MemberOnlyRoute: typeof MemberOnlyRouteWithChildren
   AnalyticsRoute: typeof AnalyticsRouteWithChildren
   AuthRoute: typeof AuthRouteWithChildren
   BuilderRoute: typeof BuilderRouteWithChildren
@@ -1195,7 +1079,6 @@ export interface RootRouteChildren {
 
 const rootRouteChildren: RootRouteChildren = {
   LandingRoute: LandingRouteWithChildren,
-  MemberOnlyRoute: MemberOnlyRouteWithChildren,
   AnalyticsRoute: AnalyticsRouteWithChildren,
   AuthRoute: AuthRouteWithChildren,
   BuilderRoute: BuilderRouteWithChildren,
@@ -1217,7 +1100,6 @@ export const routeTree = rootRoute
       "filePath": "__root.tsx",
       "children": [
         "/_landing",
-        "/_memberOnly",
         "/analytics",
         "/auth",
         "/builder",
@@ -1239,15 +1121,6 @@ export const routeTree = rootRoute
         "/_landing/support",
         "/_landing/terms",
         "/_landing/"
-      ]
-    },
-    "/_memberOnly": {
-      "filePath": "_memberOnly.tsx",
-      "children": [
-        "/_memberOnly/home",
-        "/_memberOnly/account/settings",
-        "/_memberOnly/account/stats",
-        "/_memberOnly/account/storage"
       ]
     },
     "/analytics": {
@@ -1307,10 +1180,6 @@ export const routeTree = rootRoute
       "filePath": "_landing/terms.tsx",
       "parent": "/_landing"
     },
-    "/_memberOnly/home": {
-      "filePath": "_memberOnly/home.tsx",
-      "parent": "/_memberOnly"
-    },
     "/auth/forgot-password": {
       "filePath": "auth/forgot-password.tsx",
       "parent": "/auth"
@@ -1362,18 +1231,6 @@ export const routeTree = rootRoute
     },
     "/player/": {
       "filePath": "player/index.tsx"
-    },
-    "/_memberOnly/account/settings": {
-      "filePath": "_memberOnly/account/settings.tsx",
-      "parent": "/_memberOnly"
-    },
-    "/_memberOnly/account/stats": {
-      "filePath": "_memberOnly/account/stats.tsx",
-      "parent": "/_memberOnly"
-    },
-    "/_memberOnly/account/storage": {
-      "filePath": "_memberOnly/account/storage.tsx",
-      "parent": "/_memberOnly"
     },
     "/analytics/items/$itemId": {
       "filePath": "analytics/items/$itemId.tsx",

--- a/src/ui/UserSwitch/UserSwitchWrapper.stories.tsx
+++ b/src/ui/UserSwitch/UserSwitchWrapper.stories.tsx
@@ -60,8 +60,8 @@ export const SignedIn = {
     const menuCanvas = within(screen.getByRole('menu'));
 
     // profile and settings buttons
-    expect(menuCanvas.getByText('Profile')).toBeVisible();
-    expect(menuCanvas.getByText('Settings')).toBeVisible();
+    expect(menuCanvas.getByText('Profile')).toBeInTheDocument();
+    expect(menuCanvas.getByText('Settings')).toBeInTheDocument();
 
     // email
     const emailText = menuCanvas.getByText(member.email);
@@ -69,7 +69,7 @@ export const SignedIn = {
 
     // sign out button
     const signOutButton = menuCanvas.getByText('Sign Out');
-    expect(signOutButton).toBeVisible();
+    expect(signOutButton).toBeInTheDocument();
   },
 } satisfies Story;
 
@@ -107,7 +107,7 @@ export const Guest = {
 
     // sign out button
     const signOutButton = menuCanvas.getByText('Sign Out');
-    expect(signOutButton).toBeVisible();
+    expect(signOutButton).toBeInTheDocument();
   },
 } satisfies Story;
 

--- a/src/ui/UserSwitch/UserSwitchWrapper.stories.tsx
+++ b/src/ui/UserSwitch/UserSwitchWrapper.stories.tsx
@@ -2,6 +2,8 @@ import {
   GuestFactory,
   ItemLoginSchemaFactory,
   ItemLoginSchemaType,
+  Member,
+  MemberFactory,
   PackedFolderItemFactory,
 } from '@graasp/sdk';
 
@@ -11,7 +13,6 @@ import { expect, screen, userEvent, within } from '@storybook/test';
 import { SMALL_AVATAR_SIZE } from '@/ui/constants.js';
 
 import Avatar from '../Avatar/Avatar.js';
-import { MOCK_CURRENT_MEMBER } from '../utils/fixtures.js';
 import UserSwitchWrapper from './UserSwitchWrapper.js';
 
 const meta = {
@@ -30,48 +31,50 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const CURRENT_MEMBER = MemberFactory();
+
 export const SignedIn = {
   args: {
-    seeProfileText: 'See Profile',
     signOutText: 'Sign Out',
-    currentMember: MOCK_CURRENT_MEMBER,
+    currentMember: CURRENT_MEMBER,
     avatar: (
       <Avatar
         maxWidth={SMALL_AVATAR_SIZE}
         maxHeight={SMALL_AVATAR_SIZE}
         url={'https://picsum.photos/100'}
-        alt={`profile image ${MOCK_CURRENT_MEMBER?.name}`}
+        alt={`profile image ${CURRENT_MEMBER.name}`}
         component={'avatar'}
         sx={{ mx: 1 }}
       />
     ),
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
+    const { currentMember } = args;
+    const member = currentMember as Member;
 
     // open dialog
-    const nameText = canvas.getByLabelText(MOCK_CURRENT_MEMBER.name);
+    const nameText = canvas.getByLabelText(member.name);
     await userEvent.click(nameText);
 
-    const menuCanvas = within(await screen.getByRole('menu'));
+    const menuCanvas = within(screen.getByRole('menu'));
 
-    // profile button
-    const profileButton = menuCanvas.getByText(SignedIn.args!.seeProfileText!);
-    expect(profileButton).toBeInTheDocument();
+    // profile and settings buttons
+    expect(menuCanvas.getByText('Profile')).toBeVisible();
+    expect(menuCanvas.getByText('Settings')).toBeVisible();
 
     // email
-    const emailText = menuCanvas.getByText(MOCK_CURRENT_MEMBER.email);
+    const emailText = menuCanvas.getByText(member.email);
     expect(emailText).toBeInTheDocument();
 
     // sign out button
-    const signOutButton = menuCanvas.getByText(SignedIn.args!.signOutText!);
-    expect(signOutButton).toBeInTheDocument();
+    const signOutButton = menuCanvas.getByText('Sign Out');
+    expect(signOutButton).toBeVisible();
   },
 } satisfies Story;
 
 export const Guest = {
   args: {
-    seeProfileText: 'See Profile',
     signOutText: 'Sign Out',
     currentMember: GuestFactory({
       itemLoginSchema: ItemLoginSchemaFactory({
@@ -84,7 +87,7 @@ export const Guest = {
         maxWidth={SMALL_AVATAR_SIZE}
         maxHeight={SMALL_AVATAR_SIZE}
         url={'https://picsum.photos/100'}
-        alt={`profile image ${MOCK_CURRENT_MEMBER?.name}`}
+        alt={`profile image`}
         component={'avatar'}
         sx={{ mx: 1 }}
       />
@@ -97,20 +100,19 @@ export const Guest = {
     const nameText = canvas.getByLabelText(args.currentMember!.name);
     await userEvent.click(nameText);
 
-    const menuCanvas = within(await screen.getByRole('menu'));
+    const menuCanvas = within(screen.getByRole('menu'));
 
     // have 2 menu items - do not show profile button
     expect(menuCanvas.getAllByRole('menuitem')).toHaveLength(2);
 
     // sign out button
-    const signOutButton = menuCanvas.getByText(SignedIn.args!.signOutText!);
-    expect(signOutButton).toBeInTheDocument();
+    const signOutButton = menuCanvas.getByText('Sign Out');
+    expect(signOutButton).toBeVisible();
   },
 } satisfies Story;
 
 export const SignedOut = {
   args: {
-    switchMemberText: 'Sign In',
     avatar: (
       <Avatar
         maxWidth={SMALL_AVATAR_SIZE}
@@ -130,10 +132,8 @@ export const SignedOut = {
     await userEvent.click(nameText);
 
     // custom content
-    const menuCanvas = within(await screen.getByRole('menu'));
-    const signInButton = menuCanvas.getByText(
-      SignedOut.args!.switchMemberText!,
-    );
+    const menuCanvas = within(screen.getByRole('menu'));
+    const signInButton = menuCanvas.getByText('Sign In');
     expect(signInButton).toBeInTheDocument();
   },
 } satisfies Story;

--- a/src/ui/UserSwitch/UserSwitchWrapper.tsx
+++ b/src/ui/UserSwitch/UserSwitchWrapper.tsx
@@ -1,14 +1,18 @@
 import type { JSX } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import {
   AccountCircle as AccountCircleIcon,
   MeetingRoom as MeetingRoomIcon,
 } from '@mui/icons-material';
-import { ListItemIcon, MenuItem, Typography } from '@mui/material';
+import { Divider, ListItemIcon, MenuItem, Typography } from '@mui/material';
 
 import { AccountType, CurrentAccount, redirect } from '@graasp/sdk';
 
+import { Settings } from 'lucide-react';
+
 import { MenuItemLink } from '@/components/ui/MenuItemLink.js';
+import { NS } from '@/config/constants.js';
 
 import Loader from '../Loader/Loader.js';
 import { UserSwitch } from './UserSwitch.js';
@@ -23,53 +27,44 @@ type Props = {
   ButtonContent?: JSX.Element;
   buttonId?: string;
   currentMember?: CurrentAccount | null;
-  // domain: string;
   isCurrentMemberLoading?: boolean;
-  // isCurrentMemberSuccess: boolean;
   redirectPath: string;
   avatar: JSX.Element;
   seeProfileButtonId?: string;
-  seeProfileText?: string;
   signedOutTooltipText?: string;
-  signInMenuItemId?: string;
+  signOutMenuItemId?: string;
+  signOutText?: string;
+  /**
+   * Name of the event that will be sent to Umami for tracking user actions
+   */
+  dataUmamiEvent?: string;
+  userMenuItems?: UserMenuItem[];
+
   /**
    * Async function used to perform the sign out
    * @param memberId Id of the user to sign out (current user)
    * @returns Promise of void
    */
   signOut: () => Promise<void>;
-  signOutMenuItemId?: string;
-  signOutText?: string;
-  // switchMember: (args: { memberId: string; domain: string }) => Promise<void>;
-  switchMemberText?: string;
-  /**
-   * Name of the event that will be sent to Umami for tracking user actions
-   */
-  dataUmamiEvent?: string;
-  userMenuItems?: UserMenuItem[];
 };
 
 export const UserSwitchWrapper = ({
   ButtonContent,
   buttonId,
   currentMember,
-  // domain,
   isCurrentMemberLoading = false,
-  // isCurrentMemberSuccess,
   redirectPath,
   avatar,
   seeProfileButtonId,
-  seeProfileText = 'See Profile',
-  signedOutTooltipText = 'You are not signed in.',
-  signInMenuItemId,
   signOut,
+  signedOutTooltipText = 'You are not signed in.',
   signOutMenuItemId,
   signOutText = 'Sign Out',
-  // switchMember,
-  switchMemberText = 'Sign in',
   userMenuItems = [],
   dataUmamiEvent,
 }: Props): JSX.Element => {
+  const { t } = useTranslation(NS.Common);
+
   if (isCurrentMemberLoading) {
     return <Loader />;
   }
@@ -98,16 +93,28 @@ export const UserSwitchWrapper = ({
       <Typography variant="subtitle2">{item.text}</Typography>
     </MenuItem>
   ));
+
   if (currentMember && currentMember.id) {
     Actions =
       currentMember.type === AccountType.Individual
         ? [
             <MenuItemLink key="seeProfile" id={seeProfileButtonId} to="/home">
               <ListItemIcon>
-                <AccountCircleIcon fontSize="large" />
+                <AccountCircleIcon />
               </ListItemIcon>
-              <Typography variant="subtitle2">{seeProfileText}</Typography>
+              <Typography variant="subtitle2">
+                {t('USER_SWITCH.PROFILE')}
+              </Typography>
             </MenuItemLink>,
+            <MenuItemLink key="settings" to="/account/settings">
+              <ListItemIcon>
+                <Settings />
+              </ListItemIcon>
+              <Typography variant="subtitle2">
+                {t('USER_SWITCH.SETTINGS')}
+              </Typography>
+            </MenuItemLink>,
+            <Divider key="divider" />,
           ]
         : [];
 
@@ -116,18 +123,18 @@ export const UserSwitchWrapper = ({
     Actions.push(
       <MenuItem key="signout" onClick={handleSignOut} id={signOutMenuItemId}>
         <ListItemIcon>
-          <MeetingRoomIcon fontSize="large" />
+          <MeetingRoomIcon />
         </ListItemIcon>
         <Typography variant="subtitle2">{signOutText}</Typography>
       </MenuItem>,
     );
   } else {
     Actions = [
-      <MenuItem key="signin" onClick={handleSignIn} id={signInMenuItemId}>
+      <MenuItem key="signin" onClick={handleSignIn}>
         <ListItemIcon>
-          <AccountCircleIcon fontSize="large" />
+          <AccountCircleIcon />
         </ListItemIcon>
-        <Typography variant="subtitle2">{switchMemberText}</Typography>
+        <Typography variant="subtitle2">{t('USER_SWITCH.SIGN_IN')}</Typography>
       </MenuItem>,
     ];
   }

--- a/src/ui/UserSwitch/UserSwitchWrapper.tsx
+++ b/src/ui/UserSwitch/UserSwitchWrapper.tsx
@@ -9,7 +9,7 @@ import { Divider, ListItemIcon, MenuItem, Typography } from '@mui/material';
 
 import { AccountType, CurrentAccount, redirect } from '@graasp/sdk';
 
-import { Settings } from 'lucide-react';
+import { SettingsIcon } from 'lucide-react';
 
 import { MenuItemLink } from '@/components/ui/MenuItemLink.js';
 import { NS } from '@/config/constants.js';
@@ -108,7 +108,7 @@ export const UserSwitchWrapper = ({
             </MenuItemLink>,
             <MenuItemLink key="settings" to="/account/settings">
               <ListItemIcon>
-                <Settings />
+                <SettingsIcon />
               </ListItemIcon>
               <Typography variant="subtitle2">
                 {t('USER_SWITCH.SETTINGS')}


### PR DESCRIPTION
<img width="222" alt="Screenshot 2025-02-05 at 14 55 15" src="https://github.com/user-attachments/assets/1e808004-b71f-4ede-96b0-52e53edfafb4" />

I added `settings` in the user drop down. 
The `UserSwitchWrapper` needs a lot of refactor, but I did a little bit while at it:
- factor out some translations
- show smaller icons

Remaining changes I can envision for further PRs:
- change the `redirect` mechanism to use links
- refactor the component to get actions as `children` instead as props. That would allow to factor out the `hooks.signOut`
- At some point get rid of the "wrapper" 
 