### PR TITLE
feat: add accessible items on home page

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,6 @@ jobs:
           browser: chrome
           quiet: true
           config-file: cypress.config.ts
-          cache-key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
         env:
           VITE_PORT: ${{ vars.VITE_PORT }}
           VITE_VERSION: ${{ vars.VITE_VERSION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ on:
   # Allow to manually trigger the workflow
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: false
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+#   cancel-in-progress: false
 
 jobs:
   build:

--- a/cypress/e2e/account/homePage.cy.ts
+++ b/cypress/e2e/account/homePage.cy.ts
@@ -81,7 +81,7 @@ class TestHelper {
   }
 }
 
-describe.skip('Upload Avatar', () => {
+describe('Upload Avatar', () => {
   let helpers: TestHelper;
   beforeEach(() => {
     helpers = new TestHelper({ currentMember: MEMBERS.BOB });
@@ -105,7 +105,7 @@ describe.skip('Upload Avatar', () => {
   });
 });
 
-describe.skip('Image is not set', () => {
+describe('Image is not set', () => {
   beforeEach(() => {
     cy.setUpApi({ currentMember: MEMBERS.BOB });
     cy.visit('/home');
@@ -120,7 +120,7 @@ describe.skip('Image is not set', () => {
   });
 });
 
-describe.skip('Check member info', () => {
+describe('Check member info', () => {
   beforeEach(() => {
     cy.setUpApi({
       currentMember: MEMBER_WITH_AVATAR,

--- a/cypress/e2e/account/homePage.cy.ts
+++ b/cypress/e2e/account/homePage.cy.ts
@@ -81,7 +81,7 @@ class TestHelper {
   }
 }
 
-describe('Upload Avatar', () => {
+describe.skip('Upload Avatar', () => {
   let helpers: TestHelper;
   beforeEach(() => {
     helpers = new TestHelper({ currentMember: MEMBERS.BOB });
@@ -105,7 +105,7 @@ describe('Upload Avatar', () => {
   });
 });
 
-describe('Image is not set', () => {
+describe.skip('Image is not set', () => {
   beforeEach(() => {
     cy.setUpApi({ currentMember: MEMBERS.BOB });
     cy.visit('/home');
@@ -120,7 +120,7 @@ describe('Image is not set', () => {
   });
 });
 
-describe('Check member info', () => {
+describe.skip('Check member info', () => {
   beforeEach(() => {
     cy.setUpApi({
       currentMember: MEMBER_WITH_AVATAR,

--- a/cypress/e2e/home/home.cy.ts
+++ b/cypress/e2e/home/home.cy.ts
@@ -1,0 +1,156 @@
+import {
+  ACCESSIBLE_ITEMS_ONLY_ME_ID,
+  CREATE_ITEM_BUTTON_ID,
+  HOME_LOAD_MORE_BUTTON_SELECTOR,
+  ITEM_SEARCH_INPUT_ID,
+  SORTING_ORDERING_SELECTOR_ASC,
+  SORTING_ORDERING_SELECTOR_DESC,
+  SORTING_SELECT_SELECTOR,
+  buildItemCard,
+} from '../../../src/config/selectors';
+import { SortingOptions } from '../../../src/modules/builder/components/table/types';
+import { ITEM_PAGE_SIZE } from '../../../src/modules/builder/constants';
+import { CURRENT_MEMBER } from '../../fixtures/members';
+import { ItemForTest } from '../../support/types';
+import { generateOwnItems } from '../builder/fixtures/items';
+
+const HOME_PATH = '/home';
+
+const ownItems = generateOwnItems(30);
+
+describe('Home', () => {
+  it('visit empty Home', () => {
+    cy.setUpApi({
+      items: [],
+    });
+
+    cy.visit(HOME_PATH);
+    cy.get(`[role="dropzone"]`).should('be.visible');
+    cy.get(`#${CREATE_ITEM_BUTTON_ID}`).should('be.visible');
+  });
+
+  describe('Features', () => {
+    beforeEach(() => {
+      cy.setUpApi({
+        items: generateOwnItems(30),
+      });
+      cy.visit(HOME_PATH);
+    });
+
+    it('Enabling show only created by me should trigger refetch', () => {
+      // a first call is done by the "recent items" components
+      cy.wait('@getAccessibleItems');
+
+      // remaining calls are done by the accessible table
+      cy.wait('@getAccessibleItems').then(({ request: { url } }) => {
+        expect(url).not.to.contain(CURRENT_MEMBER.id);
+      });
+
+      cy.get(`#${ACCESSIBLE_ITEMS_ONLY_ME_ID}`).click();
+
+      cy.wait('@getAccessibleItems').then(({ request: { url } }) => {
+        expect(url).to.contain(CURRENT_MEMBER.id);
+      });
+    });
+
+    it('Sorting & ordering', () => {
+      // a first call is done by the "recent items" components
+      cy.wait('@getAccessibleItems');
+
+      // remaining calls are done by the accessible table
+      cy.wait('@getAccessibleItems');
+
+      cy.get(`${SORTING_SELECT_SELECTOR} input`).should(
+        'have.value',
+        SortingOptions.ItemUpdatedAt,
+      );
+      cy.get(SORTING_ORDERING_SELECTOR_DESC).should('be.visible');
+
+      // change sorting
+      cy.get(SORTING_SELECT_SELECTOR).click();
+      cy.get('li[data-value="item.name"]').click();
+      cy.wait('@getAccessibleItems').then(({ request: { url } }) => {
+        expect(url).to.contain('item.name');
+        expect(url).to.contain('desc');
+      });
+
+      // change ordering
+      cy.get(SORTING_ORDERING_SELECTOR_DESC).click();
+      cy.get(SORTING_ORDERING_SELECTOR_ASC).should('be.visible');
+      cy.wait('@getAccessibleItems').then(({ request: { url } }) => {
+        expect(url).to.contain('asc');
+      });
+    });
+
+    describe('Search', () => {
+      it('Search should trigger refetch', () => {
+        // a first call is done by the "recent items" components
+        cy.wait('@getAccessibleItems');
+
+        // remaining calls are done by the accessible table
+        cy.wait('@getAccessibleItems');
+
+        const searchText = 'mysearch';
+        cy.get(`#${ITEM_SEARCH_INPUT_ID}`).type(searchText);
+
+        cy.wait('@getAccessibleItems').then(({ request: { url } }) => {
+          expect(url).to.contain(searchText);
+        });
+      });
+
+      it('Search on second page should reset page number', () => {
+        const searchText = 'mysearch';
+
+        // a first call is done by the "recent items" components
+        cy.wait('@getAccessibleItems');
+
+        // remaining calls are done by the accessible table
+        cy.wait('@getAccessibleItems');
+        // navigate to second page
+        cy.get(HOME_LOAD_MORE_BUTTON_SELECTOR).click();
+
+        cy.wait('@getAccessibleItems').then(({ request: { url } }) => {
+          expect(url).to.contain('page=2');
+        });
+        cy.get(`#${ITEM_SEARCH_INPUT_ID}`).type(searchText);
+
+        // using our custom interceptor with the search parameter we can distinguish the complete
+        // search request from possibly other incomplete search requests
+        cy.wait('@getAccessibleItems').then(({ request: { query } }) => {
+          expect(query.keywords).to.eq(searchText);
+          expect(query.page).to.eq('1');
+        });
+        cy.get(`#${buildItemCard(ownItems[0].id)}`).should('be.visible');
+      });
+    });
+
+    describe('Pagination', () => {
+      const checkGridPagination = (
+        items: ItemForTest[],
+        itemsPerPage: number = ITEM_PAGE_SIZE,
+      ) => {
+        const numberPages = Math.ceil(items.length / itemsPerPage);
+        // for each page
+        for (let i = 0; i < numberPages; i += 1) {
+          // compute items that should be on this page
+          const shouldDisplay = items.slice(0, (i + 1) * itemsPerPage);
+
+          shouldDisplay.forEach((item) => {
+            cy.get(`#${buildItemCard(item.id)}`).should('exist');
+          });
+
+          // navigate to page
+          // button does not exist for last "page"
+          if (i !== numberPages - 1) {
+            cy.get(HOME_LOAD_MORE_BUTTON_SELECTOR).click();
+          }
+        }
+      };
+
+      it('shows only items of each page', () => {
+        // using default items per page count
+        checkGridPagination(ownItems);
+      });
+    });
+  });
+});

--- a/cypress/e2e/home/home.cy.ts
+++ b/cypress/e2e/home/home.cy.ts
@@ -25,8 +25,8 @@ describe('Empty Home', () => {
     });
 
     cy.visit(HOME_PATH);
-    cy.get(`[role="dropzone"]`).should('be.visible');
-    cy.get(`#${CREATE_ITEM_BUTTON_ID}`).should('be.visible');
+    cy.get(`[role="dropzone"]`).scrollIntoView().should('be.visible');
+    cy.get(`#${CREATE_ITEM_BUTTON_ID}`).scrollIntoView().should('be.visible');
   });
 });
 
@@ -61,10 +61,9 @@ describe('Home page features', () => {
     // remaining calls are done by the accessible table
     cy.wait('@getAccessibleItems');
 
-    cy.get(`${SORTING_SELECT_SELECTOR} input`).should(
-      'have.value',
-      SortingOptions.ItemUpdatedAt,
-    );
+    cy.get(`${SORTING_SELECT_SELECTOR} input`)
+      .scrollIntoView()
+      .should('have.value', SortingOptions.ItemUpdatedAt);
     cy.get(SORTING_ORDERING_SELECTOR_DESC).should('be.visible');
 
     // change sorting

--- a/cypress/e2e/home/home.cy.ts
+++ b/cypress/e2e/home/home.cy.ts
@@ -18,7 +18,7 @@ const HOME_PATH = '/home';
 
 const ownItems = generateOwnItems(30);
 
-describe('Home', () => {
+describe('Empty Home', () => {
   it('visit empty Home', () => {
     cy.setUpApi({
       items: [],
@@ -28,129 +28,129 @@ describe('Home', () => {
     cy.get(`[role="dropzone"]`).should('be.visible');
     cy.get(`#${CREATE_ITEM_BUTTON_ID}`).should('be.visible');
   });
+});
 
-  describe('Features', () => {
-    beforeEach(() => {
-      cy.setUpApi({
-        items: generateOwnItems(30),
-      });
-      cy.visit(HOME_PATH);
+describe('Home page features', () => {
+  beforeEach(() => {
+    cy.setUpApi({
+      items: ownItems,
+    });
+    cy.visit(HOME_PATH);
+  });
+
+  it('Enabling show only created by me should trigger refetch', () => {
+    // a first call is done by the "recent items" components
+    cy.wait('@getAccessibleItems');
+
+    // remaining calls are done by the accessible table
+    cy.wait('@getAccessibleItems').then(({ request: { url } }) => {
+      expect(url).not.to.contain(CURRENT_MEMBER.id);
     });
 
-    it('Enabling show only created by me should trigger refetch', () => {
+    cy.get(`#${ACCESSIBLE_ITEMS_ONLY_ME_ID}`).click();
+
+    cy.wait('@getAccessibleItems').then(({ request: { url } }) => {
+      expect(url).to.contain(CURRENT_MEMBER.id);
+    });
+  });
+
+  it('Sorting & ordering', () => {
+    // a first call is done by the "recent items" components
+    cy.wait('@getAccessibleItems');
+
+    // remaining calls are done by the accessible table
+    cy.wait('@getAccessibleItems');
+
+    cy.get(`${SORTING_SELECT_SELECTOR} input`).should(
+      'have.value',
+      SortingOptions.ItemUpdatedAt,
+    );
+    cy.get(SORTING_ORDERING_SELECTOR_DESC).should('be.visible');
+
+    // change sorting
+    cy.get(SORTING_SELECT_SELECTOR).click();
+    cy.get('li[data-value="item.name"]').click();
+    cy.wait('@getAccessibleItems').then(({ request: { url } }) => {
+      expect(url).to.contain('item.name');
+      expect(url).to.contain('desc');
+    });
+
+    // change ordering
+    cy.get(SORTING_ORDERING_SELECTOR_DESC).click();
+    cy.get(SORTING_ORDERING_SELECTOR_ASC).should('be.visible');
+    cy.wait('@getAccessibleItems').then(({ request: { url } }) => {
+      expect(url).to.contain('asc');
+    });
+  });
+
+  describe('Search', () => {
+    it('Search should trigger refetch', () => {
       // a first call is done by the "recent items" components
       cy.wait('@getAccessibleItems');
 
       // remaining calls are done by the accessible table
-      cy.wait('@getAccessibleItems').then(({ request: { url } }) => {
-        expect(url).not.to.contain(CURRENT_MEMBER.id);
-      });
+      cy.wait('@getAccessibleItems');
 
-      cy.get(`#${ACCESSIBLE_ITEMS_ONLY_ME_ID}`).click();
+      const searchText = 'mysearch';
+      cy.get(`#${ITEM_SEARCH_INPUT_ID}`).type(searchText);
 
       cy.wait('@getAccessibleItems').then(({ request: { url } }) => {
-        expect(url).to.contain(CURRENT_MEMBER.id);
+        expect(url).to.contain(searchText);
       });
     });
 
-    it('Sorting & ordering', () => {
+    it('Search on second page should reset page number', () => {
+      const searchText = 'mysearch';
+
       // a first call is done by the "recent items" components
       cy.wait('@getAccessibleItems');
 
       // remaining calls are done by the accessible table
       cy.wait('@getAccessibleItems');
+      // navigate to second page
+      cy.get(HOME_LOAD_MORE_BUTTON_SELECTOR).click();
 
-      cy.get(`${SORTING_SELECT_SELECTOR} input`).should(
-        'have.value',
-        SortingOptions.ItemUpdatedAt,
-      );
-      cy.get(SORTING_ORDERING_SELECTOR_DESC).should('be.visible');
-
-      // change sorting
-      cy.get(SORTING_SELECT_SELECTOR).click();
-      cy.get('li[data-value="item.name"]').click();
       cy.wait('@getAccessibleItems').then(({ request: { url } }) => {
-        expect(url).to.contain('item.name');
-        expect(url).to.contain('desc');
+        expect(url).to.contain('page=2');
       });
+      cy.get(`#${ITEM_SEARCH_INPUT_ID}`).type(searchText);
 
-      // change ordering
-      cy.get(SORTING_ORDERING_SELECTOR_DESC).click();
-      cy.get(SORTING_ORDERING_SELECTOR_ASC).should('be.visible');
-      cy.wait('@getAccessibleItems').then(({ request: { url } }) => {
-        expect(url).to.contain('asc');
+      // using our custom interceptor with the search parameter we can distinguish the complete
+      // search request from possibly other incomplete search requests
+      cy.wait('@getAccessibleItems').then(({ request: { query } }) => {
+        expect(query.keywords).to.eq(searchText);
+        expect(query.page).to.eq('1');
       });
+      cy.get(`#${buildItemCard(ownItems[0].id)}`).should('be.visible');
     });
+  });
 
-    describe('Search', () => {
-      it('Search should trigger refetch', () => {
-        // a first call is done by the "recent items" components
-        cy.wait('@getAccessibleItems');
-
-        // remaining calls are done by the accessible table
-        cy.wait('@getAccessibleItems');
-
-        const searchText = 'mysearch';
-        cy.get(`#${ITEM_SEARCH_INPUT_ID}`).type(searchText);
-
-        cy.wait('@getAccessibleItems').then(({ request: { url } }) => {
-          expect(url).to.contain(searchText);
-        });
-      });
-
-      it('Search on second page should reset page number', () => {
-        const searchText = 'mysearch';
-
-        // a first call is done by the "recent items" components
-        cy.wait('@getAccessibleItems');
-
-        // remaining calls are done by the accessible table
-        cy.wait('@getAccessibleItems');
-        // navigate to second page
-        cy.get(HOME_LOAD_MORE_BUTTON_SELECTOR).click();
-
-        cy.wait('@getAccessibleItems').then(({ request: { url } }) => {
-          expect(url).to.contain('page=2');
-        });
-        cy.get(`#${ITEM_SEARCH_INPUT_ID}`).type(searchText);
-
-        // using our custom interceptor with the search parameter we can distinguish the complete
-        // search request from possibly other incomplete search requests
-        cy.wait('@getAccessibleItems').then(({ request: { query } }) => {
-          expect(query.keywords).to.eq(searchText);
-          expect(query.page).to.eq('1');
-        });
-        cy.get(`#${buildItemCard(ownItems[0].id)}`).should('be.visible');
-      });
-    });
-
-    describe('Pagination', () => {
-      const checkGridPagination = (
-        items: ItemForTest[],
-        itemsPerPage: number = ITEM_PAGE_SIZE,
-      ) => {
-        const numberPages = Math.ceil(items.length / itemsPerPage);
-        // for each page
-        for (let i = 0; i < numberPages; i += 1) {
-          // compute items that should be on this page
-          const shouldDisplay = items.slice(0, (i + 1) * itemsPerPage);
-
-          shouldDisplay.forEach((item) => {
-            cy.get(`#${buildItemCard(item.id)}`).should('exist');
-          });
-
-          // navigate to page
-          // button does not exist for last "page"
-          if (i !== numberPages - 1) {
-            cy.get(HOME_LOAD_MORE_BUTTON_SELECTOR).click();
-          }
-        }
-      };
-
-      it('shows only items of each page', () => {
-        // using default items per page count
-        checkGridPagination(ownItems);
-      });
+  describe('Pagination', () => {
+    it('shows only items of each page', () => {
+      // using default items per page count
+      checkGridPagination(ownItems);
     });
   });
 });
+
+const checkGridPagination = (
+  items: ItemForTest[],
+  itemsPerPage: number = ITEM_PAGE_SIZE,
+) => {
+  const numberPages = Math.ceil(items.length / itemsPerPage);
+  // for each page
+  for (let i = 0; i < numberPages; i += 1) {
+    // compute items that should be on this page
+    const shouldDisplay = items.slice(0, (i + 1) * itemsPerPage);
+
+    shouldDisplay.forEach((item) => {
+      cy.get(`#${buildItemCard(item.id)}`).should('exist');
+    });
+
+    // navigate to page
+    // button does not exist for last "page"
+    if (i !== numberPages - 1) {
+      cy.get(HOME_LOAD_MORE_BUTTON_SELECTOR).click();
+    }
+  }
+};

--- a/src/modules/account/home/recentItems/RecentItems.tsx
+++ b/src/modules/account/home/recentItems/RecentItems.tsx
@@ -20,7 +20,7 @@ import {
 import { DisplayItems } from './DisplayItems';
 
 // should be a multiple of 6 to create full pages that split into 2, 3 and 6 columns
-const PAGE_SIZE = 24;
+const PAGE_SIZE = 6;
 
 export function RecentItems() {
   const { t } = useTranslation(NS.Player);

--- a/src/modules/builder/components/pages/BuilderPageLayout.tsx
+++ b/src/modules/builder/components/pages/BuilderPageLayout.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'react';
 import { Helmet } from 'react-helmet-async';
 
-import { Container, Stack, Typography } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
 
 type Props = {
   id?: string;
@@ -21,26 +21,24 @@ export function BuilderPageLayout({
       <Helmet>
         <title>{title}</title>
       </Helmet>
-      <Container id={id} sx={{ pt: 1, height: '100%' }}>
-        <Stack height="100%">
-          <Stack
-            mb={2}
-            direction="row"
-            justifyContent="space-between"
-            spacing={1}
+      <Stack id={id} height="100%">
+        <Stack
+          mb={2}
+          direction="row"
+          justifyContent="space-between"
+          spacing={1}
+        >
+          <Typography
+            variant="h2"
+            component="h1"
+            sx={{ wordWrap: 'break-word' }}
           >
-            <Typography
-              variant="h2"
-              component="h1"
-              sx={{ wordWrap: 'break-word' }}
-            >
-              {title}
-            </Typography>
-            {options}
-          </Stack>
-          {children}
+            {title}
+          </Typography>
+          {options}
         </Stack>
-      </Container>
+        {children}
+      </Stack>
     </>
   );
 }

--- a/src/routes/_memberOnly/home.tsx
+++ b/src/routes/_memberOnly/home.tsx
@@ -1,23 +1,62 @@
-import { Divider, Stack } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+import { Divider, Stack, useMediaQuery, useTheme } from '@mui/material';
 
 import { createFileRoute } from '@tanstack/react-router';
 
+import { NS } from '@/config/constants';
 import { MenuTabs } from '@/modules/home/MenuTabs';
 
 import { MemberCard } from '~account/home/MemberCard';
 import { RecentItems } from '~account/home/recentItems/RecentItems';
+import { useItemSearch } from '~builder/components/item/ItemSearch';
+import { NewFolderButton } from '~builder/components/item/form/folder/NewFolderButton';
+import NewItemButton from '~builder/components/main/NewItemButton';
+import { SelectionContextProvider } from '~builder/components/main/list/SelectionContext';
+import { BuilderPageLayout } from '~builder/components/pages/BuilderPageLayout';
+import { HomeScreenContent } from '~builder/components/pages/home/HomeScreenContent';
 
 export const Route = createFileRoute('/_memberOnly/home')({
   component: HomeRoute,
 });
 
 function HomeRoute() {
+  const { t } = useTranslation(NS.Common, { keyPrefix: 'PAGE_TITLES' });
+  const theme = useTheme();
+  const isMd = useMediaQuery(theme.breakpoints.up('md'));
+
+  const itemSearch = useItemSearch();
+
   return (
     <Stack gap={4} alignItems="center">
       <MemberCard />
       <MenuTabs />
       <Divider flexItem />
       <RecentItems />
+      <Divider flexItem />
+      <BuilderPageLayout
+        title={t('MY_GRAASP')}
+        options={
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="flex-end"
+            spacing={1}
+          >
+            {itemSearch.input}
+            <NewFolderButton type={isMd ? 'button' : 'icon'} />
+            <NewItemButton
+              key="newButton"
+              size="medium"
+              type={isMd ? 'button' : 'icon'}
+            />
+          </Stack>
+        }
+      >
+        <SelectionContextProvider>
+          <HomeScreenContent searchText={itemSearch.text} />
+        </SelectionContextProvider>
+      </BuilderPageLayout>
     </Stack>
   );
 }

--- a/src/ui/Main/Main.tsx
+++ b/src/ui/Main/Main.tsx
@@ -53,6 +53,7 @@ const StyledMain = styled('main', {
     position: 'relative',
     flexGrow: 1,
     backgroundColor,
+
     // create transition for width and margin property
     transition: theme.transitions.create(['width', 'margin'], {
       easing: theme.transitions.easing.easeIn,
@@ -259,7 +260,14 @@ const MainWithDrawerContent = ({
 // this wrapper is necessary because we use the `useMainMenuOpenContext` in the
 // Content and we need to define the provider before using the hook.
 const MainWithDrawerWrapper = (props: Props): JSX.Element => (
-  <Box height="100vh" overflow="auto" display="flex" flexDirection="column">
+  <Box
+    height="100vh"
+    overflow="auto"
+    display="flex"
+    flexDirection="column"
+    // necessary to prevent scroll because of drag selection
+    sx={{ overflowX: 'hidden' }}
+  >
     <MainMenuOpenContextProvider open={props.open}>
       <MainWithDrawerContent {...props} />
     </MainMenuOpenContextProvider>


### PR DESCRIPTION
- Reduced the number of shown recent items
- display as is the accessible items (no map)
- add same tests as builder "home"

Titles do not really make sense currently, because it is set lower in the components, and is used by pages like "published" or "trash". Should we decrease all titles, or pass down the titles are components?

https://github.com/user-attachments/assets/c022961b-6e57-4fe6-b985-ccfa87e44eb5

close #833 
