### PR TITLE
fix: do not allow membership request for hidden items

### DIFF
--- a/cypress/e2e/builder/item/authorization/membershipRequest/membershipRequest.cy.ts
+++ b/cypress/e2e/builder/item/authorization/membershipRequest/membershipRequest.cy.ts
@@ -1,11 +1,16 @@
-import { FolderItemFactory, MembershipRequestStatus } from '@graasp/sdk';
+import {
+  FolderItemFactory,
+  ItemVisibilityType,
+  MembershipRequestStatus,
+} from '@graasp/sdk';
 
 import {
+  ITEM_LOGIN_SCREEN_FORBIDDEN_ID,
   MEMBERSHIP_REQUEST_PENDING_SCREEN_SELECTOR,
   REQUEST_MEMBERSHIP_BUTTON_ID,
   buildDataCyWrapper,
 } from '../../../../../../src/config/selectors';
-import { CURRENT_MEMBER } from '../../../../../fixtures/members';
+import { CURRENT_MEMBER, MEMBERS } from '../../../../../fixtures/members';
 import { buildItemPath } from '../../../utils';
 
 it('Request membership when signed in', () => {
@@ -26,6 +31,28 @@ it('Request membership when signed in', () => {
 
   // button is disabled
   cy.get(`#${REQUEST_MEMBERSHIP_BUTTON_ID}`).should('be.disabled');
+});
+it('Cannot request membership if item is hidden', () => {
+  const tmp = FolderItemFactory();
+  const item = {
+    ...tmp,
+    visibilities: [
+      {
+        type: ItemVisibilityType.Hidden,
+        item: tmp,
+        creator: MEMBERS.ANNA,
+        createdAt: '2021-08-11T12:56:36.834Z',
+        id: 'ecbfbd2a-9644-12db-ae93-0242ac130002',
+      },
+    ],
+  };
+  cy.setUpApi({
+    items: [item],
+  });
+
+  cy.visit(buildItemPath(item.id));
+
+  cy.get(`#${ITEM_LOGIN_SCREEN_FORBIDDEN_ID}`).should('be.visible');
 });
 
 it('Membership request is already sent', () => {

--- a/cypress/support/server.ts
+++ b/cypress/support/server.ts
@@ -399,6 +399,13 @@ export const mockGetItemLoginSchemaType = (items: ItemForTest[]): void => {
     ({ reply, url }) => {
       const itemId = url.slice(API_HOST.length).split('/')[2];
       const item = items.find(({ id }) => itemId === id);
+      if (
+        item.visibilities.some(({ type }) => type === ItemVisibilityType.Hidden)
+      ) {
+        return reply({
+          statusCode: StatusCodes.NOT_FOUND,
+        });
+      }
 
       // if no item login schema is defined, the backend returns null
       return reply({

--- a/cypress/support/server.ts
+++ b/cypress/support/server.ts
@@ -400,7 +400,9 @@ export const mockGetItemLoginSchemaType = (items: ItemForTest[]): void => {
       const itemId = url.slice(API_HOST.length).split('/')[2];
       const item = items.find(({ id }) => itemId === id);
       if (
-        item.visibilities.some(({ type }) => type === ItemVisibilityType.Hidden)
+        item.visibilities?.some(
+          ({ type }) => type === ItemVisibilityType.Hidden,
+        )
       ) {
         return reply({
           statusCode: StatusCodes.NOT_FOUND,

--- a/cypress/support/server.ts
+++ b/cypress/support/server.ts
@@ -400,7 +400,7 @@ export const mockGetItemLoginSchemaType = (items: ItemForTest[]): void => {
       const itemId = url.slice(API_HOST.length).split('/')[2];
       const item = items.find(({ id }) => itemId === id);
       if (
-        item.visibilities?.some(
+        item?.visibilities?.some(
           ({ type }) => type === ItemVisibilityType.Hidden,
         )
       ) {

--- a/src/routes/builder/items/$itemId.tsx
+++ b/src/routes/builder/items/$itemId.tsx
@@ -83,8 +83,11 @@ function RouteComponent() {
   } = hooks.useItem(itemId);
   const { data: currentMember, isLoading: currentMemberIsLoading } =
     hooks.useCurrentMember();
-  const { data: itemLoginSchemaType, isLoading: itemLoginSchemaTypeIsLoading } =
-    hooks.useItemLoginSchemaType({ itemId });
+  const {
+    data: itemLoginSchemaType,
+    isLoading: itemLoginSchemaTypeIsLoading,
+    isError: isItemLoginSchemaTypeError,
+  } = hooks.useItemLoginSchemaType({ itemId });
 
   const { mutate: itemLoginSignIn } = mutations.usePostItemLogin();
   const canWrite = item?.permission
@@ -163,7 +166,10 @@ function RouteComponent() {
             itemIsLoading
           }
           requestAccessContent={
-            currentMember?.type === AccountType.Individual ? (
+            currentMember?.type === AccountType.Individual &&
+            // member can request a membership if the item login type is null and not an error
+            // item login schema type can error if the item is hidden
+            !isItemLoginSchemaTypeError ? (
               <RequestAccessContent itemId={itemId} member={currentMember} />
             ) : undefined
           }

--- a/src/routes/player/$rootId/$itemId/index.tsx
+++ b/src/routes/player/$rootId/$itemId/index.tsx
@@ -41,6 +41,7 @@ function ItemPage(): JSX.Element | null {
   const {
     data: itemLoginSchemaType,
     isFetching: isLoadingItemLoginSchemaType,
+    isError: isItemLoginSchemaTypeError,
   } = hooks.useItemLoginSchemaType({ itemId });
 
   const { mutate: itemLoginSignIn } = mutations.usePostItemLogin();
@@ -61,7 +62,10 @@ function ItemPage(): JSX.Element | null {
       enrollContent={<EnrollContent itemId={itemId} />}
       forbiddenContent={<ItemForbiddenScreen />}
       requestAccessContent={
-        member?.type === AccountType.Individual ? (
+        member?.type === AccountType.Individual &&
+        // member can request a membership if the item login type is null and not an error
+        // item login schema type can error if the item is hidden
+        !isItemLoginSchemaTypeError ? (
           <RequestAccessContent itemId={itemId} member={member} />
         ) : undefined
       }


### PR DESCRIPTION
This PR solves the problem where before a hidden item could show the membership request feature. It was because the requesting was based on the fact that an item was not found + had no item login schema. It did not make the difference between `ITEM_NOT_FOUND` and item schema type `null`. 

So the fix is based on the returned value of `itemLoginSchemaType` that could return an error. If it's the case the item might not exist or be hidden. In those case we do not show the membership request button.