### PR TITLE
feat: move tutorials in user drop down, add return home button

### DIFF
--- a/src/locales/ar/builder.json
+++ b/src/locales/ar/builder.json
@@ -364,7 +364,6 @@
   "FLAG_REASON_DESCRIPTION": "حدد سبب وضع علامة على هذا العنصر",
   "FLAG_MODAL_TITLE": "إبلاغ عن العنصر",
   "FLAG_MODAL_CONFIRM": "إبلاغ",
-  "TUTORIALS": "دروس",
   "NEW_SHORT_LINK_BUTTON": "رابط قصير جديد",
   "CONFIRM_DELETE_SHORT_LINK_TITLE": "تأكيد قمع الارتباط القصير؟",
   "CONFIRM_DELETE_SHORT_LINK_MSG": "أنت تقوم بإزالة الرابط القصير {{shortLink}}، هل تريد المتابعة؟",

--- a/src/locales/de/builder.json
+++ b/src/locales/de/builder.json
@@ -364,7 +364,6 @@
   "FLAG_REASON_DESCRIPTION": "Wählen Sie den Grund für die Meldung dieses Inhaltes aus",
   "FLAG_MODAL_TITLE": "Inhalt melden",
   "FLAG_MODAL_CONFIRM": "Melden",
-  "TUTORIALS": "Tutorials",
   "NEW_SHORT_LINK_BUTTON": "Neuer Kurzlink",
   "CONFIRM_DELETE_SHORT_LINK_TITLE": "Unterdrückung des Kurzlinks bestätigen?",
   "CONFIRM_DELETE_SHORT_LINK_MSG": "Sie entfernen den Kurzlink {{shortLink}}. Möchten Sie fortfahren?",

--- a/src/locales/en/builder.json
+++ b/src/locales/en/builder.json
@@ -3,7 +3,8 @@
     "MY_ITEMS": "My Graasp",
     "BOOKMARKED_ITEMS": "Bookmarks",
     "PUBLISHED_ITEMS": "Published",
-    "RECYCLED_ITEMS": "Trash"
+    "RECYCLED_ITEMS": "Trash",
+    "RETURN_HOME": "Return to Home"
   },
   "REDIRECTION_TEXT": "Redirection",
   "REDIRECTION_BUTTON": "Navigate to redirection",
@@ -528,6 +529,5 @@
   "TAGS_LEVEL_HELPERTEXT": "Example: elementary, high school, undergraduate",
   "TAGS_RESOURCE_TYPE_HELPERTEXT": "Example: article, video, quiz",
   "ITEM_TYPE_COULD_NOT_BE_HANDLED": "Item type {{type}} could not be handled",
-  "SHORTCUT_FETCHING_ISSUE": "There was an issue fetching the content for this shortcut item.",
-  "RETURN_HOME": "Return to Home"
+  "SHORTCUT_FETCHING_ISSUE": "There was an issue fetching the content for this shortcut item."
 }

--- a/src/locales/en/builder.json
+++ b/src/locales/en/builder.json
@@ -368,7 +368,6 @@
   "FLAG_REASON_DESCRIPTION": "Select reason for flagging this item",
   "FLAG_MODAL_TITLE": "Flag Item",
   "FLAG_MODAL_CONFIRM": "Flag",
-  "TUTORIALS": "Tutorials",
   "NEW_SHORT_LINK_BUTTON": "New short link",
   "CONFIRM_DELETE_SHORT_LINK_TITLE": "Confirm the suppression of the short link ?",
   "CONFIRM_DELETE_SHORT_LINK_MSG": "You are removing the short link {{shortLink}}, do you want to continue ?",
@@ -529,5 +528,6 @@
   "TAGS_LEVEL_HELPERTEXT": "Example: elementary, high school, undergraduate",
   "TAGS_RESOURCE_TYPE_HELPERTEXT": "Example: article, video, quiz",
   "ITEM_TYPE_COULD_NOT_BE_HANDLED": "Item type {{type}} could not be handled",
-  "SHORTCUT_FETCHING_ISSUE": "There was an issue fetching the content for this shortcut item."
+  "SHORTCUT_FETCHING_ISSUE": "There was an issue fetching the content for this shortcut item.",
+  "RETURN_HOME": "Return to Home"
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -64,6 +64,7 @@
     "PROFILE": "Profile",
     "SETTINGS": "Settings",
     "STORAGE": "Storage",
-    "SIGN_IN": "Sign In"
+    "SIGN_IN": "Sign In",
+    "NEED_HELP": "Need help?"
   }
 }

--- a/src/locales/es/builder.json
+++ b/src/locales/es/builder.json
@@ -355,7 +355,6 @@
   "FLAG_REASON_DESCRIPTION": "Seleccione el motivo para marcar este elemento",
   "FLAG_MODAL_TITLE": "Artículo de bandera",
   "FLAG_MODAL_CONFIRM": "Bandera",
-  "TUTORIALS": "Tutoriales",
   "NEW_SHORT_LINK_BUTTON": "Nuevo enlace corto",
   "CONFIRM_DELETE_SHORT_LINK_TITLE": "¿Confirmar la supresión del enlace corto?",
   "CONFIRM_DELETE_SHORT_LINK_MSG": "Estás eliminando el enlace corto {{shortLink}}, ¿quieres continuar?",

--- a/src/locales/fr/builder.json
+++ b/src/locales/fr/builder.json
@@ -360,7 +360,6 @@
   "FLAG_REASON_DESCRIPTION": "Sélectionnez la raison du signalement de cet élément",
   "FLAG_MODAL_TITLE": "Signalez cet élément",
   "FLAG_MODAL_CONFIRM": "Signaler",
-  "TUTORIALS": "Tutoriels",
   "NEW_SHORT_LINK_BUTTON": "Nouveau lien rapide",
   "CONFIRM_DELETE_SHORT_LINK_TITLE": "Confirmez-vous la suppression du lien rapide ?",
   "CONFIRM_DELETE_SHORT_LINK_MSG": "Vous êtes sur le point de supprimer le lien rapide {{shortLink}}, voulez-vous continuer ?",

--- a/src/locales/it/builder.json
+++ b/src/locales/it/builder.json
@@ -365,7 +365,6 @@
   "FLAG_REASON_DESCRIPTION": "Seleziona il motivo per cui segnalare questo elemento",
   "FLAG_MODAL_TITLE": "Elemento segnalato",
   "FLAG_MODAL_CONFIRM": "Segnala",
-  "TUTORIALS": "Tutorial",
   "NEW_SHORT_LINK_BUTTON": "Nuovo link breve",
   "CONFIRM_DELETE_SHORT_LINK_TITLE": "Confermi l'eliminazione del link breve?",
   "CONFIRM_DELETE_SHORT_LINK_MSG": "Stai rimuovendo il link breve {{shortLink}}, vuoi continuare?",

--- a/src/modules/builder/components/layout/Navigation.tsx
+++ b/src/modules/builder/components/layout/Navigation.tsx
@@ -1,25 +1,15 @@
 import type { JSX } from 'react';
 
-import { IconButton } from '@mui/material';
-
-import { AccountType } from '@graasp/sdk';
-
-import { Link, useParams } from '@tanstack/react-router';
-import { Home } from 'lucide-react';
+import { useParams } from '@tanstack/react-router';
 
 import { hooks } from '@/config/queryClient';
-import {
-  NAVIGATION_HOME_ID,
-  NAVIGATION_ROOT_ID,
-  buildNavigationLink,
-} from '@/config/selectors';
+import { NAVIGATION_ROOT_ID, buildNavigationLink } from '@/config/selectors';
 import { Navigation } from '@/ui/Navigation/Navigation';
 
-const { useItem, useParents, useCurrentMember, useChildren } = hooks;
+const { useItem, useParents, useChildren } = hooks;
 
 const Navigator = (): JSX.Element | null => {
   const { itemId } = useParams({ strict: false });
-  const { data: currentMember } = useCurrentMember();
   const { data: item, isLoading: isItemLoading } = useItem(itemId);
 
   const { data: parents, isLoading: areParentsLoading } = useParents({
@@ -30,28 +20,12 @@ const Navigator = (): JSX.Element | null => {
     return null;
   }
 
-  const renderRoot = () => {
-    // no access to root if signed out
-    if (currentMember?.type !== AccountType.Individual) {
-      return null;
-    }
-
-    return (
-      <Link to="/builder" search={(prev) => ({ ...prev })}>
-        <IconButton id={NAVIGATION_HOME_ID}>
-          <Home />
-        </IconButton>
-      </Link>
-    );
-  };
-
   return (
     <Navigation
       id={NAVIGATION_ROOT_ID}
       item={item}
       itemPath={`/builder/items/$itemId`}
       parents={parents}
-      renderRoot={renderRoot}
       buildMenuItemId={buildNavigationLink}
       useChildren={useChildren}
     />

--- a/src/modules/builder/components/main/MainMenu.tsx
+++ b/src/modules/builder/components/main/MainMenu.tsx
@@ -1,15 +1,7 @@
 import type { JSX } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import {
-  Box,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  Stack,
-} from '@mui/material';
+import { Box, List, Stack } from '@mui/material';
 
 import { AccountType } from '@graasp/sdk';
 
@@ -23,24 +15,8 @@ import {
 import { useAuth } from '@/AuthContext';
 import { MainMenuItem } from '@/components/ui/MainMenuItem';
 import { NS } from '@/config/constants';
+import { NAVIGATION_HOME_ID } from '@/config/selectors';
 import { DRAWER_WIDTH } from '@/ui/constants';
-
-const ResourceLinks = () => {
-  const { t } = useTranslation(NS.Builder);
-  return (
-    <ListItem disablePadding>
-      <ListItemButton
-        href={'/home'}
-        // data-umami-event="sidebar-tutorials"
-      >
-        <ListItemIcon>
-          <HomeIcon />
-        </ListItemIcon>
-        <ListItemText>{t('RETURN_HOME')}</ListItemText>
-      </ListItemButton>
-    </ListItem>
-  );
-};
 
 export function MainMenu(): JSX.Element | null {
   const { t } = useTranslation(NS.Builder, { keyPrefix: 'MENU' });
@@ -81,7 +57,13 @@ export function MainMenu(): JSX.Element | null {
           ) : null}
         </List>
         <Box>
-          <ResourceLinks />
+          <MainMenuItem
+            id={NAVIGATION_HOME_ID}
+            text={t('RETURN_HOME')}
+            icon={<HomeIcon />}
+            to="/home"
+          />
+          ;
         </Box>
       </Stack>
     );

--- a/src/modules/builder/components/main/MainMenu.tsx
+++ b/src/modules/builder/components/main/MainMenu.tsx
@@ -14,7 +14,6 @@ import {
 import { AccountType } from '@graasp/sdk';
 
 import {
-  BookOpenTextIcon,
   BookmarkIcon,
   HomeIcon,
   LibraryBigIcon,
@@ -26,22 +25,18 @@ import { MainMenuItem } from '@/components/ui/MainMenuItem';
 import { NS } from '@/config/constants';
 import { DRAWER_WIDTH } from '@/ui/constants';
 
-import { TUTORIALS_LINK } from '../../constants';
-import { BUILDER } from '../../langs';
-
 const ResourceLinks = () => {
   const { t } = useTranslation(NS.Builder);
   return (
     <ListItem disablePadding>
       <ListItemButton
-        href={TUTORIALS_LINK}
-        target="_blank"
+        href={'/home'}
         // data-umami-event="sidebar-tutorials"
       >
         <ListItemIcon>
-          <BookOpenTextIcon />
+          <HomeIcon />
         </ListItemIcon>
-        <ListItemText>{t(BUILDER.TUTORIALS)}</ListItemText>
+        <ListItemText>{t('RETURN_HOME')}</ListItemText>
       </ListItemButton>
     </ListItem>
   );

--- a/src/ui/Navigation/Navigation.stories.tsx
+++ b/src/ui/Navigation/Navigation.stories.tsx
@@ -58,7 +58,7 @@ const useChildren: ItemMenuProps['useChildren'] = () => {
   return { data: children } as UseChildrenHookType;
 };
 const itemPath = '/itemPath';
-const dataTestId = 'NavigateNextIcon';
+const navigateNextIconDataTestId = 'NavigateNextIcon';
 const folder = FolderItemFactory({
   id: 'folder-id',
   name: 'folder',
@@ -90,8 +90,8 @@ export const FolderWithParents = {
       expect(b).toBeInTheDocument();
     }
 
-    // 4 = 2 parents + 2 x Home + current item is a folder
-    expect(canvas.getAllByTestId(dataTestId)).toHaveLength(5);
+    // 3 = 2 parents + current item is a folder
+    expect(canvas.getAllByTestId(navigateNextIconDataTestId)).toHaveLength(3);
   },
 } satisfies Story;
 
@@ -116,8 +116,8 @@ export const FileWithParents = {
       expect(b).toBeInTheDocument();
     }
 
-    // 4 = 2 parents + 2 x Home
-    expect(canvas.getAllByTestId(dataTestId)).toHaveLength(4);
+    // 2 parents
+    expect(canvas.getAllByTestId(navigateNextIconDataTestId)).toHaveLength(2);
   },
 } satisfies Story;
 
@@ -156,7 +156,7 @@ export const FolderWithParentsWithExtraItems = {
       expect(b).toBeInTheDocument();
     }
 
-    // 4 = 2 parents + 2 x Home + current item is a folder + 1 extra item
-    expect(canvas.getAllByTestId(dataTestId)).toHaveLength(5);
+    // 3 = 2 parents + current item is a folder + 1 extra item
+    expect(canvas.getAllByTestId(navigateNextIconDataTestId)).toHaveLength(3);
   },
 } satisfies Story;

--- a/src/ui/Navigation/Navigation.stories.tsx
+++ b/src/ui/Navigation/Navigation.stories.tsx
@@ -12,8 +12,7 @@ import { CogIcon } from 'lucide-react';
 
 import { MOCK_MEMBER } from '../utils/fixtures.js';
 import ExtraItemsMenu from './ExtraItemsMenu.js';
-import HomeMenu from './HomeMenu.js';
-import { ItemMenu, ItemMenuProps, Navigation } from './Navigation.js';
+import { ItemMenuProps, Navigation } from './Navigation.js';
 
 const buildItem = (name: string): LocalFileItemType =>
   LocalFileItemFactory({
@@ -70,64 +69,12 @@ const folder = FolderItemFactory({
   creator: MOCK_MEMBER,
 });
 
-const menu = [
-  { name: 'Home', id: 'home', to: 'home' },
-  { name: 'Shared Items', id: 'shared', to: 'shared' },
-];
-
-export const HomeRoot = {
-  args: {
-    itemPath,
-    useChildren,
-
-    renderRoot: () => {
-      return (
-        <>
-          <HomeMenu selected={menu[0]} elements={menu} />
-          <ItemMenu
-            itemId={item.id}
-            useChildren={() => {
-              return {
-                data: [buildItem('Home item 1'), buildItem('Home item 2')],
-              } as UseChildrenHookType;
-            }}
-            itemPath="/itemPath"
-          />
-        </>
-      );
-    },
-  },
-
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // 2 x Home
-    expect(canvas.getAllByTestId(dataTestId)).toHaveLength(2);
-  },
-} satisfies Story;
-
 export const FolderWithParents = {
   args: {
     itemPath,
     useChildren,
     item: folder,
 
-    renderRoot: () => {
-      return (
-        <>
-          <HomeMenu selected={menu[0]} elements={menu} />
-          <ItemMenu
-            itemId={item.id}
-            useChildren={() => {
-              return {
-                data: [buildItem('Home item 1'), buildItem('Home item 2')],
-              } as UseChildrenHookType;
-            }}
-            itemPath={itemPath}
-          />
-        </>
-      );
-    },
     parents,
   },
 
@@ -154,22 +101,6 @@ export const FileWithParents = {
     useChildren,
     item,
 
-    renderRoot: () => {
-      return (
-        <>
-          <HomeMenu selected={menu[0]} elements={menu} />
-          <ItemMenu
-            itemId={item.id}
-            useChildren={() => {
-              return {
-                data: [buildItem('Home item 1'), buildItem('Home item 2')],
-              } as UseChildrenHookType;
-            }}
-            itemPath={itemPath}
-          />
-        </>
-      );
-    },
     parents,
   },
 
@@ -209,22 +140,6 @@ export const FolderWithParentsWithExtraItems = {
     useChildren,
     item: folder,
     maxItems: 10,
-    renderRoot: () => {
-      return (
-        <>
-          <HomeMenu selected={menu[0]} elements={menu} />
-          <ItemMenu
-            itemId={item.id}
-            useChildren={() => {
-              return {
-                data: [buildItem('Home item 1'), buildItem('Home item 2')],
-              } as UseChildrenHookType;
-            }}
-            itemPath={itemPath}
-          />
-        </>
-      );
-    },
     parents,
     children: extraItems,
   },

--- a/src/ui/Navigation/Navigation.tsx
+++ b/src/ui/Navigation/Navigation.tsx
@@ -39,7 +39,6 @@ export type NavigationProps = {
   id?: string;
   item?: DiscriminatedItem;
   parents?: DiscriminatedItem[];
-  renderRoot?: (item?: DiscriminatedItem) => JSX.Element | null;
   sx?: SxProps;
   useChildren: UseChildrenType;
   maxItems?: number;
@@ -59,7 +58,6 @@ export function Navigation({
   id,
   item,
   parents,
-  renderRoot,
   sx,
   useChildren,
   buildMenuId,
@@ -75,9 +73,6 @@ export function Navigation({
       aria-label="breadcrumb"
       style={{ backgroundColor }}
     >
-      <Stack direction="row" alignItems="center" justifyContent="center">
-        {renderRoot?.(item)}
-      </Stack>
       {item?.id && parents && (
         <ParentsNavigation
           useChildren={useChildren}

--- a/src/ui/UserSwitch/UserSwitchWrapper.tsx
+++ b/src/ui/UserSwitch/UserSwitchWrapper.tsx
@@ -9,7 +9,7 @@ import { Divider, ListItemIcon, MenuItem, Typography } from '@mui/material';
 
 import { AccountType, CurrentAccount, redirect } from '@graasp/sdk';
 
-import { SettingsIcon } from 'lucide-react';
+import { CircleHelpIcon, SettingsIcon } from 'lucide-react';
 
 import { MenuItemLink } from '@/components/ui/MenuItemLink.js';
 import { NS } from '@/config/constants.js';
@@ -115,6 +115,14 @@ export const UserSwitchWrapper = ({
               </Typography>
             </MenuItemLink>,
             <Divider key="divider" />,
+            <MenuItemLink key="help" to="/support">
+              <ListItemIcon>
+                <CircleHelpIcon />
+              </ListItemIcon>
+              <Typography variant="subtitle2">
+                {t('USER_SWITCH.NEED_HELP')}
+              </Typography>
+            </MenuItemLink>,
           ]
         : [];
 


### PR DESCRIPTION
- Move "Tutorials" to "Need help?" in user drop down
- Remove root from breadcrumbs 
- Add "Return to Home" instead of "tutorials" at the bottom of the drawer

<img width="514" alt="Screenshot 2025-02-11 at 17 21 46" src="https://github.com/user-attachments/assets/4b704c51-3566-4e2e-a5cd-27af5d8b9548" /> 
<img width="203" alt="Screenshot 2025-02-11 at 17 21 41" src="https://github.com/user-attachments/assets/dc1b23b0-f546-4524-8424-354aef717e0d" /> 

close #838 