### PR TITLE
fix: change profile to home in user menu popup

### DIFF
--- a/src/components/ui/HeaderRightContent.tsx
+++ b/src/components/ui/HeaderRightContent.tsx
@@ -35,7 +35,7 @@ export function HeaderRightContent() {
         />
 
         <UserPopupMenu
-          buttonId={HEADER_MEMBER_MENU_BUTTON_ID}
+          avatarButtonId={HEADER_MEMBER_MENU_BUTTON_ID}
           signOut={logout}
           user={user}
           avatar={<MemberAvatar id={user.id} />}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -61,7 +61,7 @@
     "TRASH": "Trash"
   },
   "USER_SWITCH": {
-    "PROFILE": "Profile",
+    "HOME": "Home",
     "SETTINGS": "Settings",
     "STORAGE": "Storage",
     "LOG_IN": "Log in",

--- a/src/ui/UserPopupMenu.stories.tsx
+++ b/src/ui/UserPopupMenu.stories.tsx
@@ -14,6 +14,7 @@ const meta = {
     signOut: { action: 'signOut' },
   },
   args: {
+    avatarButtonId: 'popup-button',
     signOut: fn(),
   },
 } satisfies Meta<typeof UserPopupMenu>;
@@ -31,7 +32,6 @@ const CURRENT_USER = {
 
 export const SignedIn = {
   args: {
-    buttonId: 'popup-button',
     signOutText: 'Sign Out',
     user: CURRENT_USER,
     avatar: (

--- a/src/ui/UserPopupMenu.stories.tsx
+++ b/src/ui/UserPopupMenu.stories.tsx
@@ -54,7 +54,7 @@ export const SignedIn = {
     const menuCanvas = within(screen.getByRole('menu'));
 
     // profile and settings buttons
-    expect(menuCanvas.getByText('Profile')).toBeInTheDocument();
+    expect(menuCanvas.getByText('Home')).toBeInTheDocument();
     expect(menuCanvas.getByText('Settings')).toBeInTheDocument();
 
     // sign out button

--- a/src/ui/UserPopupMenu.tsx
+++ b/src/ui/UserPopupMenu.tsx
@@ -1,4 +1,9 @@
-import { type JSX, type MouseEventHandler, useState } from 'react';
+import {
+  ComponentProps,
+  type JSX,
+  type MouseEventHandler,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -15,8 +20,8 @@ import { AccountType } from '@graasp/sdk';
 import {
   CircleHelpIcon,
   DoorOpenIcon,
+  HomeIcon,
   SettingsIcon,
-  UserCircle2Icon,
 } from 'lucide-react';
 
 import { AuthenticatedMember } from '@/AuthContext';
@@ -26,10 +31,9 @@ import { NS } from '@/config/constants';
 const MENU_ARIA_ID = 'account-menu';
 
 type Props = {
-  buttonId?: string;
+  avatarButtonId: string;
   avatar: JSX.Element;
   user: AuthenticatedMember;
-  seeProfileButtonId?: string;
   signOutMenuItemId?: string;
   signOutText: string;
   /**
@@ -46,9 +50,8 @@ type Props = {
 };
 
 export function UserPopupMenu({
-  buttonId,
+  avatarButtonId,
   user,
-  seeProfileButtonId,
   signOutMenuItemId,
   avatar,
   dataUmamiEvent,
@@ -68,13 +71,19 @@ export function UserPopupMenu({
     setAnchorEl(null);
   };
 
+  const activeProps: ComponentProps<
+    typeof MenuItemLink
+  >['activeProps'] = () => ({
+    selected: true,
+  });
+
   const open = Boolean(anchorEl);
   return (
     <>
       <IconButton
         onClick={handleClick}
         size="small"
-        id={buttonId}
+        id={avatarButtonId}
         aria-controls={open ? MENU_ARIA_ID : undefined}
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
@@ -91,21 +100,20 @@ export function UserPopupMenu({
         {user.type === AccountType.Individual && (
           <>
             <MenuItemLink
-              key="seeProfile"
-              id={seeProfileButtonId}
               to="/home"
+              activeProps={activeProps}
               onClick={handleClose}
             >
               <ListItemIcon>
-                <UserCircle2Icon />
+                <HomeIcon />
               </ListItemIcon>
               <Typography variant="subtitle2">
-                {t('USER_SWITCH.PROFILE')}
+                {t('USER_SWITCH.HOME')}
               </Typography>
             </MenuItemLink>
             <MenuItemLink
-              key="settings"
               to="/account/settings"
+              activeProps={activeProps}
               onClick={handleClose}
             >
               <ListItemIcon>
@@ -115,8 +123,12 @@ export function UserPopupMenu({
                 {t('USER_SWITCH.SETTINGS')}
               </Typography>
             </MenuItemLink>
-            <Divider key="divider" />
-            <MenuItemLink key="help" to="/support" onClick={handleClose}>
+            <Divider />
+            <MenuItemLink
+              to="/support"
+              activeProps={activeProps}
+              onClick={handleClose}
+            >
               <ListItemIcon>
                 <CircleHelpIcon />
               </ListItemIcon>


### PR DESCRIPTION
In this PR:
Change text in user menu popup from "Profile" to "Home".

In builder:
<img width="269" alt="Screenshot 2025-02-13 at 15 47 09" src="https://github.com/user-attachments/assets/eae54f53-a3dc-43fe-b954-e130e8e542c5" />

In home (notice that since we are in the /home route, the item is selected):
<img width="229" alt="Screenshot 2025-02-13 at 15 47 02" src="https://github.com/user-attachments/assets/8ba203fa-6c4f-4af2-aecb-ce9b6d68c494" />


close #914 