### PR TITLE
feat: reset scroll on player navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@storybook/react-vite": "8.5.4",
     "@storybook/test": "8.5.4",
     "@tanstack/react-query-devtools": "5.66.0",
-    "@tanstack/router-plugin": "1.102.2",
+    "@tanstack/router-plugin": "1.104.1",
     "@testing-library/dom": "10.4.0",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "16.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,8 +262,8 @@ importers:
         specifier: 5.66.0
         version: 5.66.0(@tanstack/react-query@5.66.0(react@19.0.0))(react@19.0.0)
       '@tanstack/router-plugin':
-        specifier: 1.102.2
-        version: 1.102.2(@tanstack/react-router@1.102.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@6.1.0(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.19.2))(webpack@5.97.1(esbuild@0.24.2))
+        specifier: 1.104.1
+        version: 1.104.1(@tanstack/react-router@1.102.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@6.1.0(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.19.2))(webpack@5.97.1(esbuild@0.24.2))
       '@testing-library/dom':
         specifier: 10.4.0
         version: 10.4.0
@@ -456,20 +456,12 @@ packages:
     resolution: {integrity: sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.26.5':
-    resolution: {integrity: sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/compat-data@7.26.8':
     resolution: {integrity: sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.26.0':
     resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/core@7.26.7':
-    resolution: {integrity: sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.26.8':
@@ -2272,21 +2264,21 @@ packages:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
-  '@tanstack/router-generator@1.102.2':
-    resolution: {integrity: sha512-nZjEQDqKCNBGDWfOFYe4++5YorBJJPSCzjCQtTzGoOrTuugA8Y/R1+k87eBz/AH3qdZFvBNqL3ipozbBbNpe1A==}
+  '@tanstack/router-generator@1.104.1':
+    resolution: {integrity: sha512-1z75mOOEZxNTKUSNOZk1/liTx6TidqXqcZTT/JI6gWoGxqx3EVnhv0iqK3CHxlzrIvrr3akRuVU1mjEY42BHRQ==}
     engines: {node: '>=12'}
     peerDependencies:
-      '@tanstack/react-router': ^1.102.1
+      '@tanstack/react-router': ^1.104.1
     peerDependenciesMeta:
       '@tanstack/react-router':
         optional: true
 
-  '@tanstack/router-plugin@1.102.2':
-    resolution: {integrity: sha512-JuTCnMLogBmj5v/LKqxO9Smt61AKhR+5l1v1JHF5X/9nWA1HMXj4vrnrVWwh0mZVYQff1Ecuwos/gA4tlSVAWw==}
+  '@tanstack/router-plugin@1.104.1':
+    resolution: {integrity: sha512-TUkO9wg962XHsvAUOIWqc+8jxJ16CdBje59FEB9NpnX2wy/9c9AJ6iV5RfWUbSntni/HfTXE9uNd4oWSTwDrXg==}
     engines: {node: '>=12'}
     peerDependencies:
       '@rsbuild/core': '>=1.0.2'
-      '@tanstack/react-router': ^1.102.1
+      '@tanstack/react-router': ^1.104.1
       vite: '>=5.0.0 || >=6.0.0'
       webpack: '>=5.92.0'
     peerDependenciesMeta:
@@ -6755,8 +6747,6 @@ snapshots:
 
   '@babel/compat-data@7.26.3': {}
 
-  '@babel/compat-data@7.26.5': {}
-
   '@babel/compat-data@7.26.8': {}
 
   '@babel/core@7.26.0':
@@ -6767,26 +6757,6 @@ snapshots:
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
       '@babel/helpers': 7.26.0
-      '@babel/parser': 7.26.7
-      '@babel/template': 7.25.9
-      '@babel/traverse': 7.26.7
-      '@babel/types': 7.26.7
-      convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@8.1.1)
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/core@7.26.7':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.26.5
-      '@babel/helper-compilation-targets': 7.26.5
-      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.7)
-      '@babel/helpers': 7.26.7
       '@babel/parser': 7.26.7
       '@babel/template': 7.25.9
       '@babel/traverse': 7.26.7
@@ -6850,7 +6820,7 @@ snapshots:
 
   '@babel/helper-compilation-targets@7.26.5':
     dependencies:
-      '@babel/compat-data': 7.26.5
+      '@babel/compat-data': 7.26.8
       '@babel/helper-validator-option': 7.25.9
       browserslist: 4.24.4
       lru-cache: 5.1.1
@@ -6896,8 +6866,8 @@ snapshots:
 
   '@babel/helper-module-imports@7.25.9':
     dependencies:
-      '@babel/traverse': 7.26.7
-      '@babel/types': 7.26.7
+      '@babel/traverse': 7.26.8
+      '@babel/types': 7.26.8
     transitivePeerDependencies:
       - supports-color
 
@@ -6906,16 +6876,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.26.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.7)':
-    dependencies:
-      '@babel/core': 7.26.7
-      '@babel/helper-module-imports': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.26.7
+      '@babel/traverse': 7.26.8
     transitivePeerDependencies:
       - supports-color
 
@@ -6924,7 +6885,7 @@ snapshots:
       '@babel/core': 7.26.8
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.26.7
+      '@babel/traverse': 7.26.8
     transitivePeerDependencies:
       - supports-color
 
@@ -6977,17 +6938,17 @@ snapshots:
 
   '@babel/helpers@7.26.0':
     dependencies:
-      '@babel/template': 7.25.9
-      '@babel/types': 7.26.7
+      '@babel/template': 7.26.8
+      '@babel/types': 7.26.8
 
   '@babel/helpers@7.26.7':
     dependencies:
-      '@babel/template': 7.25.9
-      '@babel/types': 7.26.7
+      '@babel/template': 7.26.8
+      '@babel/types': 7.26.8
 
   '@babel/parser@7.26.3':
     dependencies:
-      '@babel/types': 7.26.7
+      '@babel/types': 7.26.8
 
   '@babel/parser@7.26.7':
     dependencies:
@@ -7489,7 +7450,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/parser': 7.26.7
-      '@babel/types': 7.26.7
+      '@babel/types': 7.26.8
 
   '@babel/template@7.26.8':
     dependencies:
@@ -8843,7 +8804,7 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/router-generator@1.102.2(@tanstack/react-router@1.102.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@tanstack/router-generator@1.104.1(@tanstack/react-router@1.102.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       '@tanstack/virtual-file-routes': 1.99.0
       prettier: 3.5.0
@@ -8852,7 +8813,7 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-router': 1.102.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
-  '@tanstack/router-plugin@1.102.2(@tanstack/react-router@1.102.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@6.1.0(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.19.2))(webpack@5.97.1(esbuild@0.24.2))':
+  '@tanstack/router-plugin@1.104.1(@tanstack/react-router@1.102.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(vite@6.1.0(@types/node@22.13.1)(jiti@2.4.2)(terser@5.38.2)(tsx@4.19.2))(webpack@5.97.1(esbuild@0.24.2))':
     dependencies:
       '@babel/core': 7.26.8
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.8)
@@ -8860,7 +8821,7 @@ snapshots:
       '@babel/template': 7.26.8
       '@babel/traverse': 7.26.8
       '@babel/types': 7.26.8
-      '@tanstack/router-generator': 1.102.2(@tanstack/react-router@1.102.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+      '@tanstack/router-generator': 1.104.1(@tanstack/react-router@1.102.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@tanstack/router-utils': 1.102.2
       '@tanstack/virtual-file-routes': 1.99.0
       '@types/babel__core': 7.20.5
@@ -8966,16 +8927,16 @@ snapshots:
 
   '@types/babel__generator@7.6.8':
     dependencies:
-      '@babel/types': 7.26.7
+      '@babel/types': 7.26.8
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.26.7
-      '@babel/types': 7.26.7
+      '@babel/parser': 7.26.8
+      '@babel/types': 7.26.8
 
   '@types/babel__traverse@7.20.6':
     dependencies:
-      '@babel/types': 7.26.7
+      '@babel/types': 7.26.8
 
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
@@ -11526,7 +11487,7 @@ snapshots:
 
   istanbul-lib-instrument@4.0.3:
     dependencies:
-      '@babel/core': 7.26.7
+      '@babel/core': 7.26.8
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -11535,7 +11496,7 @@ snapshots:
 
   istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.26.7
+      '@babel/core': 7.26.8
       '@babel/parser': 7.26.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2

--- a/src/config/selectors.ts
+++ b/src/config/selectors.ts
@@ -629,3 +629,5 @@ export const MEMBERSHIP_REQUEST_REJECT_BUTTON_SELECTOR =
 export const VISIBILITY_HIDDEN_ALERT_ID = 'visibilityHiddenAlert';
 export const SHARE_ITEM_CANCEL_BUTTON_CY = 'shareItemCancelButton';
 export const ADD_FOLDER_BUTTON_CY = 'addFolder';
+
+export const MAIN_WITH_DRAWER_ID = 'mainWithDrawer';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -75,6 +75,7 @@ const router = createRouter({
     // at this stage, we set it to `undefined`. A more appropriate value will be set later in AuthProvider when we wrap the app.
     auth: undefined!,
   },
+  scrollRestoration: true,
 });
 
 // Register things for typesafety

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -2,11 +2,7 @@ import { Suspense, lazy } from 'react';
 
 import { Stack } from '@mui/material';
 
-import {
-  Outlet,
-  ScrollRestoration,
-  createRootRouteWithContext,
-} from '@tanstack/react-router';
+import { Outlet, createRootRouteWithContext } from '@tanstack/react-router';
 
 import { AuthContextType } from '@/AuthContext';
 import { DefaultCatchBoundary } from '@/components/DefaultCatchBoundary';
@@ -43,7 +39,6 @@ const TanStackRouterDevtools =
 function RootComponent() {
   return (
     <Stack id="__root" minHeight="100vh">
-      <ScrollRestoration />
       <PreviewContextProvider>
         <Outlet />
       </PreviewContextProvider>

--- a/src/routes/player/$rootId/$itemId.tsx
+++ b/src/routes/player/$rootId/$itemId.tsx
@@ -1,4 +1,4 @@
-import { type JSX, type ReactNode } from 'react';
+import { type JSX, type ReactNode, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Box, Typography, useTheme } from '@mui/material';
@@ -14,6 +14,7 @@ import { HeaderRightContent } from '@/components/ui/HeaderRightContent';
 import { NS } from '@/config/constants';
 import { GRAASP_LIBRARY_HOST } from '@/config/env';
 import { hooks } from '@/config/queryClient';
+import { MAIN_WITH_DRAWER_ID } from '@/config/selectors';
 import Main from '@/ui/Main/Main';
 import PlatformSwitch from '@/ui/PlatformSwitch/PlatformSwitch';
 import { Platform } from '@/ui/PlatformSwitch/hooks';
@@ -68,6 +69,16 @@ function PlayerWrapper(): JSX.Element {
     },
   };
 
+  // reset scroll on navigation
+  useEffect(() => {
+    const mainComponent = document.getElementById(MAIN_WITH_DRAWER_ID);
+    mainComponent?.scrollTo({
+      top: 0,
+      left: 0,
+      behavior: 'smooth',
+    });
+  }, [itemId]);
+
   if (fullscreen) {
     return (
       /* necessary for item login screen to be centered */
@@ -90,6 +101,7 @@ function PlayerWrapper(): JSX.Element {
       drawerContent={<ItemNavigation />}
       drawerOpenAriaLabel={t('DRAWER_ARIAL_LABEL')}
       LinkComponent={LinkComponent}
+      id={MAIN_WITH_DRAWER_ID}
       PlatformComponent={
         <PlatformSwitch
           selected={Platform.Player}

--- a/src/ui/Main/Main.tsx
+++ b/src/ui/Main/Main.tsx
@@ -70,6 +70,8 @@ const StyledFooter = styled('footer', {
 }));
 
 type Props = {
+  id?: string;
+
   /**
    * Platform value which defines what color to use in the header.
    */
@@ -267,6 +269,7 @@ const MainWithDrawerWrapper = (props: Props): JSX.Element => (
     flexDirection="column"
     // necessary to prevent scroll because of drag selection
     sx={{ overflowX: 'hidden' }}
+    id={props.id}
   >
     <MainMenuOpenContextProvider open={props.open}>
       <MainWithDrawerContent {...props} />


### PR DESCRIPTION
I really tried to make tanstack-router work with their `scrollRestoration` feature.
However we need the `scrollToTopSelectors` prop https://tanstack.com/router/latest/docs/framework/react/guide/scroll-restoration#hashtop-of-page-scrolling but it doesn't seem to exist in the current version? We need this prop because it is not the `window` that needs scrolling, but the `main` element (window is always `scroll: 0`, we fake scrolling with a div because of the drawer).

So currently my solution is a dirty `useEffect` on each `itemId`change.

Another alternative could be to change the whole structure of the `<Main />` component, where the header and drawer are inside some `div` in fixed, while the `div` handles margin and scroll.. let me know what you think. 

close #928 