### PR TITLE
refactor: move home button to top, remove unused showNavigation prop

### DIFF
--- a/cypress/e2e/builder/item/view/viewFolder.cy.ts
+++ b/cypress/e2e/builder/item/view/viewFolder.cy.ts
@@ -135,7 +135,7 @@ describe('view Folder as admin', () => {
     const searchText = child1.name;
     cy.visit(buildItemPath(id, { mode: ItemLayoutMode.Grid }));
     // initial call in the page
-    cy.wait(['@getChildren', '@getChildren']);
+    cy.wait(['@getChildren']);
 
     cy.get(`#${buildItemCard(child1.id)}`).should('be.visible');
 

--- a/src/locales/en/builder.json
+++ b/src/locales/en/builder.json
@@ -4,7 +4,7 @@
     "BOOKMARKED_ITEMS": "Bookmarks",
     "PUBLISHED_ITEMS": "Published",
     "RECYCLED_ITEMS": "Trash",
-    "RETURN_HOME": "Return to Home"
+    "RETURN_HOME": "Home"
   },
   "REDIRECTION_TEXT": "Redirection",
   "REDIRECTION_BUTTON": "Navigate to redirection",

--- a/src/locales/fr/builder.json
+++ b/src/locales/fr/builder.json
@@ -4,7 +4,7 @@
     "BOOKMARKED_ITEMS": "Signets",
     "PUBLISHED_ITEMS": "Publications",
     "RECYCLED_ITEMS": "Corbeille",
-    "RETURN_HOME": "Retour à l'accueil"
+    "RETURN_HOME": "Accueil"
   },
   "REDIRECTION_TEXT": "Redirection",
   "REDIRECTION_BUTTON": "Accéder à la redirection",

--- a/src/modules/builder/components/item/ItemMain.tsx
+++ b/src/modules/builder/components/item/ItemMain.tsx
@@ -39,7 +39,6 @@ const ItemMain = ({ id, children }: Props): JSX.Element => {
       <Stack direction="row" id={id} className={ITEM_MAIN_CLASS} height="100%">
         <Stack p={2} width="100%">
           <ItemHeader
-            showNavigation
             isChatboxOpen={isChatboxOpen}
             toggleChatbox={toggleChatbox}
           />

--- a/src/modules/builder/components/item/header/ItemHeader.tsx
+++ b/src/modules/builder/components/item/header/ItemHeader.tsx
@@ -13,7 +13,6 @@ import Navigation from '~builder/components/layout/Navigation';
 import ItemHeaderActions from './ItemHeaderActions';
 
 type Props = {
-  showNavigation?: boolean;
   isChatboxOpen: boolean;
   toggleChatbox: () => void;
 };
@@ -21,7 +20,6 @@ type Props = {
 const ItemHeader = ({
   isChatboxOpen,
   toggleChatbox,
-  showNavigation = false,
 }: Readonly<Props>): JSX.Element | null => {
   const { itemId } = useParams({ strict: false });
   const { t: translateBuilder } = useTranslation(NS.Builder);
@@ -33,14 +31,15 @@ const ItemHeader = ({
       mb={1}
       id={ITEM_HEADER_ID}
     >
-      {/* display empty div to render actions on the right */}
-      {showNavigation ? <Navigation /> : <div />}
+      <Navigation />
       {itemId ? (
-        <ItemHeaderActions
-          itemId={itemId}
-          isChatboxOpen={isChatboxOpen}
-          toggleChatbox={toggleChatbox}
-        />
+        <Stack flexGrow={1} alignItems="flex-end">
+          <ItemHeaderActions
+            itemId={itemId}
+            isChatboxOpen={isChatboxOpen}
+            toggleChatbox={toggleChatbox}
+          />
+        </Stack>
       ) : (
         <Alert severity="error">{translateBuilder('ERROR_MESSAGE')}</Alert>
       )}

--- a/src/routes/builder/items/$itemId.tsx
+++ b/src/routes/builder/items/$itemId.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Stack, useTheme } from '@mui/material';
+import { Divider, Stack, useTheme } from '@mui/material';
 
 import {
   AccountType,
@@ -126,7 +126,14 @@ function RouteComponent() {
   const drawerContent = isParentsLoading ? (
     <LoadingTree />
   ) : (
-    <Stack justifyContent="space-between" height="100%">
+    <Stack height="100%">
+      <MainMenuItem
+        id={NAVIGATION_HOME_ID}
+        text={t('MENU.RETURN_HOME')}
+        icon={<HomeIcon />}
+        to="/home"
+      />
+      <Divider />
       <ItemNavigation
         rootId={parents?.[0]?.id ?? itemId}
         itemId={
@@ -147,12 +154,6 @@ function RouteComponent() {
             search,
           });
         }}
-      />
-      <MainMenuItem
-        id={NAVIGATION_HOME_ID}
-        text={t('MENU.RETURN_HOME')}
-        icon={<HomeIcon />}
-        to="/home"
       />
     </Stack>
   );

--- a/src/routes/builder/items/$itemId/index.tsx
+++ b/src/routes/builder/items/$itemId/index.tsx
@@ -38,7 +38,6 @@ function RouteComponent(): JSX.Element {
         <Stack direction="row" className={ITEM_MAIN_CLASS} height="100%">
           <Stack p={2} width="100%" maxWidth="xl" mx="auto">
             <ItemHeader
-              showNavigation
               isChatboxOpen={isChatboxOpen}
               toggleChatbox={toggleChatbox}
             />

--- a/src/ui/Navigation/Navigation.tsx
+++ b/src/ui/Navigation/Navigation.tsx
@@ -64,6 +64,10 @@ export function Navigation({
   maxItems = 4,
   children,
 }: Readonly<NavigationProps>): JSX.Element | null {
+  if (!parents?.length) {
+    return null;
+  }
+
   return (
     <StyledBreadcrumbs
       sx={sx}


### PR DESCRIPTION
- Move "Return to Home" at the top of the drawer
- Remove `showNavigation` that was never used `false`
- Do not show breadcrumb navigation in root of the hierarchy