### PR TITLE
fix: simplify ws config in query client, define a ws client for prod

### DIFF
--- a/src/config/queryClient.ts
+++ b/src/config/queryClient.ts
@@ -1,3 +1,5 @@
+import { configureWebsocketClient } from '@graasp/sdk';
+
 import { configureQueryClient } from '@/query';
 
 import { API_HOST, SHOW_NOTIFICATIONS } from './env';
@@ -20,6 +22,7 @@ const {
     keepPreviousData: true,
   },
   SHOW_NOTIFICATIONS,
+  wsClient: configureWebsocketClient(`${API_HOST.replace('http', 'ws')}/ws`),
 });
 export {
   useQueryClient,

--- a/src/query/queryClient.ts
+++ b/src/query/queryClient.ts
@@ -1,5 +1,3 @@
-import { configureWebsocketClient } from '@graasp/sdk';
-
 import {
   HydrationBoundary,
   QueryCache,
@@ -57,7 +55,6 @@ export type ConfigureQueryClientConfig = Partial<
     | 'API_HOST'
     | 'SHOW_NOTIFICATIONS'
     | 'wsClient'
-    | 'WS_HOST'
     | 'notifier'
     | 'defaultQueryOptions'
   >
@@ -68,16 +65,12 @@ export default (config: ConfigureQueryClientConfig) => {
     API_HOST: config.API_HOST ?? 'http://localhost:3000',
     SHOW_NOTIFICATIONS: config.SHOW_NOTIFICATIONS || false,
   };
-
   // define config for query client
   const queryConfig: QueryClientConfig = {
     ...baseConfig,
     axios: axiosClient,
-    // derive WS_HOST from API_HOST if needed
-    WS_HOST:
-      config.WS_HOST ?? `${baseConfig.API_HOST.replace('http', 'ws')}/ws`,
     // whether websocket support should be enabled
-    enableWebsocket: config.wsClient != null,
+    enableWebsocket: Boolean(config.wsClient),
     notifier: config.notifier,
     // default hooks & mutation config
     defaultQueryOptions: {
@@ -117,10 +110,9 @@ export default (config: ConfigureQueryClientConfig) => {
   const mutations = configureMutations(queryConfig);
 
   // set up hooks given config
-  const websocketClient =
-    queryConfig.wsClient != null
-      ? (queryConfig.wsClient ?? configureWebsocketClient(queryConfig.WS_HOST))
-      : undefined;
+  const websocketClient = queryConfig.enableWebsocket
+    ? config.wsClient
+    : undefined;
   const hooks = configureHooks(queryConfig, websocketClient);
 
   // returns the queryClient and relative instances

--- a/src/query/test/constants.ts
+++ b/src/query/test/constants.ts
@@ -48,7 +48,6 @@ type MockFastifyError = {
   origin: string;
 };
 
-export const WS_HOST = 'ws://localhost:3000';
 export const UNAUTHORIZED_RESPONSE: MockFastifyError = {
   name: 'unauthorized',
   code: 'ERRCODE',

--- a/src/query/test/utils.tsx
+++ b/src/query/test/utils.tsx
@@ -20,7 +20,6 @@ import {
 } from '../config/constants.js';
 import configureQueryClient from '../queryClient.js';
 import { Notifier, QueryClientConfig } from '../types.js';
-import { WS_HOST } from './constants.js';
 
 export type Handler = { channel: Channel; handler: (event: unknown) => void };
 
@@ -53,8 +52,7 @@ export const setUpTest = (args?: Args) => {
     SHOW_NOTIFICATIONS: false,
     notifier,
     enableWebsocket,
-    wsClient: enableWebsocket ? websocketClient : null, // use default
-    WS_HOST,
+    wsClient: enableWebsocket ? websocketClient : undefined, // use default
   };
 
   const { mutations, hooks, QueryClientProvider, queryClient } =

--- a/src/query/test/wsUtils.tsx
+++ b/src/query/test/wsUtils.tsx
@@ -10,7 +10,6 @@ import { API_HOST } from '@/config/env.js';
 import { axiosClient } from '../api/axios.js';
 import configureQueryClient from '../queryClient.js';
 import { Notifier, QueryClientConfig } from '../types.js';
-import { WS_HOST } from './constants.js';
 
 export type Handler = { channel: Channel; handler: (event: unknown) => void };
 
@@ -48,7 +47,6 @@ export const setUpWsTest = <T extends object>(args: {
     notifier,
     enableWebsocket: true,
     wsClient: websocketClient,
-    WS_HOST,
   };
 
   const { QueryClientProvider, useMutation, queryClient } =

--- a/src/query/types.ts
+++ b/src/query/types.ts
@@ -35,9 +35,8 @@ export type Notifier = (
 export type QueryClientConfig = {
   API_HOST: string;
   SHOW_NOTIFICATIONS: boolean;
-  WS_HOST: string;
   enableWebsocket: boolean;
-  wsClient?: WebsocketClient | null;
+  wsClient?: WebsocketClient;
   notifier?: Notifier;
   axios: AxiosInstance;
   defaultQueryOptions?: {


### PR DESCRIPTION
No ws client was defined for prod. I simplified the code as well to remove the `WS_HOST` prop.