### PR TITLE
fix: app resizing issue

### DIFF
--- a/src/modules/builder/components/item/ItemContent.tsx
+++ b/src/modules/builder/components/item/ItemContent.tsx
@@ -140,7 +140,7 @@ const AppContent = ({
   <AppItem
     isResizable={false}
     item={item}
-    height={ITEM_DEFAULT_HEIGHT}
+    height="100%"
     requestApiAccessToken={(payload: {
       id: string;
       key: string;

--- a/src/ui/items/AppItem.tsx
+++ b/src/ui/items/AppItem.tsx
@@ -21,15 +21,16 @@ const AppIFrame = styled('iframe')<{
 }>(({ isResizable }) => ({
   ...iframeCommonStyles,
   /**
-   * IMPORTANT to not override the height when using dynamic sizing
-   * The present styles are applied with higher specificity, so the dynamic height
-   * provided by the app using the resizing mechanism is ignored.
+   * IMPORTANT The height set here will have a class precedence.
+   * The auto height hook will set the height on the style property
+   *  of the element itself giving it a higher precedence
+   * thus overriding this value. This is what we want.
    */
-  height: !isResizable ? undefined : '100%',
+  height: !isResizable ? '70vh' : '100%',
+  width: '100%',
 }));
 
-const DEFAULT_APP_HEIGHT = 400;
-const APP_ITEM_WIDTH = '100%';
+const DEFAULT_RESIZING_HEIGHT = 400;
 /**
  * This query param is added to the fetched url to fix an issue where the browser
  * is able to aggressively cache the `index.html` file for the app.
@@ -90,7 +91,7 @@ const AppItem = ({
   item,
   contextPayload,
   requestApiAccessToken,
-  height = DEFAULT_APP_HEIGHT,
+  height,
   frameId,
   memberId,
   isResizable = false,
@@ -134,13 +135,12 @@ const AppItem = ({
       src={appUrlWithQuery}
       sx={{ visibility: isIFrameLoading ? 'hidden' : 'visible' }}
       title={item?.name}
-      width={APP_ITEM_WIDTH}
       allow="fullscreen"
     />
   );
 
   const ResizableIframe = withResizing({
-    height,
+    height: height ?? DEFAULT_RESIZING_HEIGHT,
     memberId: memberId,
     itemId: item.id,
     component: iframe,

--- a/src/ui/items/AppItem.tsx
+++ b/src/ui/items/AppItem.tsx
@@ -18,7 +18,7 @@ import withResizing from './withResizing.js';
 
 const AppIFrame = styled('iframe')<{
   isResizable?: boolean;
-}>(({ isResizable }) => ({
+}>(({ isResizable, height }) => ({
   ...iframeCommonStyles,
   /**
    * IMPORTANT The height set here will have a class precedence.
@@ -26,7 +26,7 @@ const AppIFrame = styled('iframe')<{
    *  of the element itself giving it a higher precedence
    * thus overriding this value. This is what we want.
    */
-  height: !isResizable ? '70vh' : '100%',
+  height: !isResizable ? height : '100%',
   width: '100%',
 }));
 
@@ -135,6 +135,7 @@ const AppItem = ({
       src={appUrlWithQuery}
       sx={{ visibility: isIFrameLoading ? 'hidden' : 'visible' }}
       title={item?.name}
+      height={height ?? '80vh'}
       allow="fullscreen"
     />
   );

--- a/src/ui/items/appItemHooks.ts
+++ b/src/ui/items/appItemHooks.ts
@@ -91,7 +91,9 @@ const useAppCommunication = ({
               if (typeof payload !== 'number') {
                 return;
               }
-              iFrameRef.current.height = payload.toString();
+              // set the element height using the style prop
+              // we use the style prop since it allows us to have higher precedence than when using the height prop
+              iFrameRef.current.style.height = `${payload}px`;
               break;
             }
           }

--- a/src/ui/items/withCaption.tsx
+++ b/src/ui/items/withCaption.tsx
@@ -93,7 +93,13 @@ export const CaptionWrapper = <T extends WithCaptionItem>({
   const description = normalizeDescription(item.description);
 
   return (
-    <Stack direction={direction} gap={0.5} alignItems={alignItems} width="100%">
+    <Stack
+      direction={direction}
+      gap={0.5}
+      alignItems={alignItems}
+      width="100%"
+      height="100%"
+    >
       {children}
       <TextDisplay content={description} />
     </Stack>


### PR DESCRIPTION
In this PR I fix an issue with app resizing.

The current situation is that apps that want to be perfectly fit (using the autoresize hook) will send their height and it will be applied to the `height="xxx"` prop of the iframe. 
The apps that do not send this info will not have a height set, sot hey will be very small.

We want:
- apps using auto-resize should have their specified height used
- apps **not** using auto-resize should have a large height (around the full-viewport)
- apps using the resizable wrapper should be able to be resized by the component

The issue previously was that if we specified a height in the styling class, then the hook-provided height applied on the element directly would be override it, because it has lower specificity.

The fix is to change where we put the hook-provided height: using `ref.current.style.height` instead of `ref.current.height` we get the highest specificity possible, so it correctly overrides the default height.
We are then able to give the iframe a default height on the iframe class and all works well.

