### PR TITLE
fix: use update password generation to fix translation

### DIFF
--- a/cypress/support/server.ts
+++ b/cypress/support/server.ts
@@ -669,7 +669,9 @@ export const mockCreatePassword = (shouldThrowError: boolean): void => {
     },
     ({ reply }) => {
       if (shouldThrowError) {
-        return reply({ statusCode: StatusCodes.BAD_REQUEST });
+        return reply({
+          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        });
       }
 
       return reply({ status: StatusCodes.NO_CONTENT });

--- a/src/config/notifier.ts
+++ b/src/config/notifier.ts
@@ -9,7 +9,6 @@ import { NS } from './constants';
 import { SHOW_NOTIFICATIONS } from './env';
 
 const {
-  updatePasswordRoutine,
   postPublicProfileRoutine,
   patchPublicProfileRoutine,
   updateEmailRoutine,
@@ -59,7 +58,6 @@ export default ({
     // error messages
     // auth
     case getInvitationRoutine.FAILURE:
-    case updatePasswordRoutine.FAILURE:
     case postPublicProfileRoutine.FAILURE:
     case updateEmailRoutine.FAILURE:
     case patchPublicProfileRoutine.FAILURE: {
@@ -69,7 +67,6 @@ export default ({
 
     // success messages
     // auth
-    case updatePasswordRoutine.SUCCESS:
     case postPublicProfileRoutine.SUCCESS:
     case updateEmailRoutine.SUCCESS:
     case patchPublicProfileRoutine.SUCCESS: {

--- a/src/modules/account/settings/password/CreatePassword.tsx
+++ b/src/modules/account/settings/password/CreatePassword.tsx
@@ -9,7 +9,6 @@ import { Alert, Stack, Typography } from '@mui/material';
 import { isPasswordStrong } from '@graasp/sdk';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 
 import { BorderedSection } from '@/components/layout/BorderedSection';
 import { Button } from '@/components/ui/Button';
@@ -60,10 +59,12 @@ const CreatePassword = ({ onClose }: CreatePasswordProps): JSX.Element => {
   } = useMutation({
     ...postPasswordMutation(),
     onSuccess: () => {
+      // toast success on another page because the form will be closed
       toast.success(translateMessage('UPDATE_PASSWORD'));
     },
     onError: (e) => {
-      toast.error(e.message);
+      // error will be shown below
+      console.error(e);
     },
     onSettled: () => {
       queryClient.invalidateQueries({
@@ -89,11 +90,13 @@ const CreatePassword = ({ onClose }: CreatePasswordProps): JSX.Element => {
     newPasswordErrorMessage ?? confirmNewPasswordErrorMessage,
   );
 
-  const createNetworkError = isAxiosError(createPasswordError)
-    ? translateMessage(
-        createPasswordError.response?.data.name ?? 'UNEXPECTED_ERROR',
-      )
+  const createNetworkError: string | null = createPasswordError?.message
+    ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      (translateMessage(createPasswordError?.message) ??
+      translateMessage('UNEXPECTED_ERROR'))
     : null;
+
   return (
     <BorderedSection
       id={PASSWORD_CREATE_CONTAINER_ID}

--- a/src/modules/account/settings/password/CreatePassword.tsx
+++ b/src/modules/account/settings/password/CreatePassword.tsx
@@ -90,11 +90,12 @@ const CreatePassword = ({ onClose }: CreatePasswordProps): JSX.Element => {
     newPasswordErrorMessage ?? confirmNewPasswordErrorMessage,
   );
 
-  const createNetworkError: string | null = createPasswordError?.message
-    ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
-      (translateMessage(createPasswordError?.message) ??
-      translateMessage('UNEXPECTED_ERROR'))
+  const createNetworkError = createPasswordError
+    ? (translateMessage(
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        createPasswordError?.message ?? translateMessage('UNEXPECTED_ERROR'),
+      ) satisfies string)
     : null;
 
   return (

--- a/src/modules/account/settings/password/EditPassword.tsx
+++ b/src/modules/account/settings/password/EditPassword.tsx
@@ -9,7 +9,6 @@ import { Alert, Box, Stack, Typography } from '@mui/material';
 import { isPasswordStrong } from '@graasp/sdk';
 
 import { useMutation } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 
 import { BorderedSection } from '@/components/layout/BorderedSection';
 import { Button } from '@/components/ui/Button';
@@ -62,14 +61,12 @@ const EditPassword = ({ onClose }: EditPasswordProps): JSX.Element => {
 
   const onSubmit: SubmitHandler<Inputs> = async (data) => {
     try {
-      // perform password update
       await updatePassword({
         body: {
           password: data.newPassword,
           currentPassword: data.currentPassword,
         },
       });
-
       onClose();
     } catch (e) {
       console.error(e);
@@ -80,15 +77,17 @@ const EditPassword = ({ onClose }: EditPasswordProps): JSX.Element => {
   const newPasswordErrorMessage = errors.newPassword?.message;
   const confirmNewPasswordErrorMessage = errors.confirmNewPassword?.message;
   const hasErrors = Boolean(
-    currentPasswordErrorMessage ||
-      newPasswordErrorMessage ||
+    currentPasswordErrorMessage ??
+      newPasswordErrorMessage ??
       confirmNewPasswordErrorMessage,
   );
 
-  const updateNetworkError = isAxiosError(updatePasswordError)
-    ? translateMessage(
-        updatePasswordError.response?.data.name ?? 'UNEXPECTED_ERROR',
-      )
+  const updateNetworkError = updatePasswordError
+    ? (translateMessage(
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        updatePasswordError?.message ?? 'UNEXPECTED_ERROR',
+      ) satisfies string)
     : null;
 
   return (

--- a/src/modules/account/settings/password/EditPassword.tsx
+++ b/src/modules/account/settings/password/EditPassword.tsx
@@ -53,7 +53,10 @@ const EditPassword = ({ onClose }: EditPasswordProps): JSX.Element => {
   } = useMutation({
     ...patchPasswordMutation(),
     onSuccess: () => {
-      toast.success(translateMessage('UPDATE_PASSWORD', { ns: NS.Messages }));
+      toast.success(translateMessage('UPDATE_PASSWORD'));
+    },
+    onError: (e) => {
+      toast.error(e.message);
     },
   });
 

--- a/src/modules/account/settings/password/EditPassword.tsx
+++ b/src/modules/account/settings/password/EditPassword.tsx
@@ -1,18 +1,19 @@
 import type { JSX } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'react-toastify';
 
 import { LoadingButton } from '@mui/lab';
 import { Alert, Box, Stack, Typography } from '@mui/material';
 
 import { isPasswordStrong } from '@graasp/sdk';
 
+import { useMutation } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 
 import { BorderedSection } from '@/components/layout/BorderedSection';
 import { Button } from '@/components/ui/Button';
 import { NS } from '@/config/constants';
-import { mutations } from '@/config/queryClient';
 import {
   PASSWORD_EDIT_CONTAINER_ID,
   PASSWORD_INPUT_CONFIRM_PASSWORD_ID,
@@ -20,6 +21,7 @@ import {
   PASSWORD_INPUT_NEW_PASSWORD_ID,
   PASSWORD_SAVE_BUTTON_ID,
 } from '@/config/selectors';
+import { patchPasswordMutation } from '@/openapi/client/@tanstack/react-query.gen';
 
 import { PasswordField } from './PasswordField';
 
@@ -48,14 +50,21 @@ const EditPassword = ({ onClose }: EditPasswordProps): JSX.Element => {
     mutateAsync: updatePassword,
     error: updatePasswordError,
     isPending: isUpdatePasswordLoading,
-  } = mutations.useUpdatePassword();
+  } = useMutation({
+    ...patchPasswordMutation(),
+    onSuccess: () => {
+      toast.success(translateMessage('UPDATE_PASSWORD', { ns: NS.Messages }));
+    },
+  });
 
   const onSubmit: SubmitHandler<Inputs> = async (data) => {
     try {
       // perform password update
       await updatePassword({
-        password: data.newPassword,
-        currentPassword: data.currentPassword,
+        body: {
+          password: data.newPassword,
+          currentPassword: data.currentPassword,
+        },
       });
 
       onClose();

--- a/src/modules/auth/components/signIn/MagicLinkLoginForm.tsx
+++ b/src/modules/auth/components/signIn/MagicLinkLoginForm.tsx
@@ -7,6 +7,7 @@ import { Stack } from '@mui/material';
 import { RecaptchaAction } from '@graasp/sdk';
 
 import { useLocation, useNavigate } from '@tanstack/react-router';
+import isEmail from 'validator/lib/isEmail';
 
 import { NS } from '@/config/constants';
 import { mutations } from '@/config/queryClient';
@@ -16,7 +17,6 @@ import {
 } from '@/config/selectors';
 
 import { AUTH } from '~auth/langs';
-import { isEmailValid } from '~auth/validation';
 
 import { executeCaptcha } from '../../context/RecaptchaContext';
 import { useMobileAppLogin } from '../../hooks/useMobileAppLogin';
@@ -85,6 +85,7 @@ export function MagicLinkLoginForm({
       console.error(e);
     }
   };
+
   const emailError = errors.email?.message;
 
   return (
@@ -102,7 +103,12 @@ export function MagicLinkLoginForm({
         form={register('email', {
           required: t('REQUIRED_FIELD_ERROR'),
           validate: {
-            email: (value) => isEmailValid(value) || t('INVALID_EMAIL_ERROR'),
+            email: (value) => {
+              if (!value) {
+                return t('EMPTY_EMAIL_ERROR');
+              }
+              return isEmail(value, {}) ? true : t('INVALID_EMAIL_ERROR');
+            },
           },
         })}
         placeholder={t(AUTH.EMAIL_INPUT_PLACEHOLDER)}

--- a/src/modules/auth/components/signIn/MagicLinkLoginForm.tsx
+++ b/src/modules/auth/components/signIn/MagicLinkLoginForm.tsx
@@ -4,10 +4,9 @@ import { useTranslation } from 'react-i18next';
 import { LoadingButton } from '@mui/lab';
 import { Stack } from '@mui/material';
 
-import { RecaptchaAction } from '@graasp/sdk';
+import { RecaptchaAction, isEmail } from '@graasp/sdk';
 
 import { useLocation, useNavigate } from '@tanstack/react-router';
-import isEmail from 'validator/lib/isEmail';
 
 import { NS } from '@/config/constants';
 import { mutations } from '@/config/queryClient';
@@ -38,6 +37,9 @@ export function MagicLinkLoginForm({
 }: Readonly<MagicLinkLoginFormProps>) {
   const navigate = useNavigate();
   const location = useLocation();
+  const { t: translateCommon } = useTranslation(NS.Common, {
+    keyPrefix: 'FIELD_ERROR',
+  });
   const { t } = useTranslation(NS.Auth);
 
   const {
@@ -101,15 +103,9 @@ export function MagicLinkLoginForm({
         // eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus
         form={register('email', {
-          required: t('REQUIRED_FIELD_ERROR'),
-          validate: {
-            email: (value) => {
-              if (!value) {
-                return t('EMPTY_EMAIL_ERROR');
-              }
-              return isEmail(value, {}) ? true : t('INVALID_EMAIL_ERROR');
-            },
-          },
+          required: translateCommon('REQUIRED'),
+          validate: (email) =>
+            isEmail(email, {}) || translateCommon('INVALID_EMAIL'),
         })}
         placeholder={t(AUTH.EMAIL_INPUT_PLACEHOLDER)}
         error={emailError}

--- a/src/modules/auth/validation.ts
+++ b/src/modules/auth/validation.ts
@@ -42,13 +42,6 @@ export const emailValidator = (email?: string) => {
   return isEmail(email, {}) ? null : INVALID_EMAIL_ERROR;
 };
 
-export const isEmailValid = (email?: string) => {
-  if (!email) {
-    return EMPTY_EMAIL_ERROR;
-  }
-  return isEmail(email, {}) ? true : INVALID_EMAIL_ERROR;
-};
-
 export const passwordValidator = (password?: string) => {
   if (!password || password.trim().length == 0) {
     return PASSWORD_EMPTY_ERROR;

--- a/src/query/member/api.ts
+++ b/src/query/member/api.ts
@@ -6,7 +6,6 @@ import {
   MemberStorageItem,
   Paginated,
   Pagination,
-  Password,
   UUID,
 } from '@graasp/sdk';
 
@@ -30,7 +29,6 @@ import {
   buildGetMemberStorageRoute,
   buildPatchCurrentMemberRoute,
   buildPostMemberEmailUpdateRoute,
-  buildPostMemberPasswordRoute,
   buildUploadAvatarRoute,
 } from './routes.js';
 
@@ -108,11 +106,6 @@ export const deleteCurrentMember = async () =>
       .delete<void>(`${API_HOST}/${buildDeleteCurrentMemberRoute()}`)
       .then(({ data }) => data),
   );
-
-export const createPassword = async (payload: { password: Password }) =>
-  axios
-    .post<void>(`${API_HOST}/${buildPostMemberPasswordRoute()}`, payload)
-    .then((data) => data);
 
 export const uploadAvatar = async (args: {
   file: Blob;

--- a/src/query/member/api.ts
+++ b/src/query/member/api.ts
@@ -29,7 +29,6 @@ import {
   buildGetMemberStorageFilesRoute,
   buildGetMemberStorageRoute,
   buildPatchCurrentMemberRoute,
-  buildPatchMemberPasswordRoute,
   buildPostMemberEmailUpdateRoute,
   buildPostMemberPasswordRoute,
   buildUploadAvatarRoute,
@@ -113,14 +112,6 @@ export const deleteCurrentMember = async () =>
 export const createPassword = async (payload: { password: Password }) =>
   axios
     .post<void>(`${API_HOST}/${buildPostMemberPasswordRoute()}`, payload)
-    .then((data) => data);
-
-export const updatePassword = async (payload: {
-  password: Password;
-  currentPassword: Password;
-}) =>
-  axios
-    .patch<void>(`${API_HOST}/${buildPatchMemberPasswordRoute()}`, payload)
     .then((data) => data);
 
 export const uploadAvatar = async (args: {

--- a/src/query/member/mutations.test.ts
+++ b/src/query/member/mutations.test.ts
@@ -19,7 +19,6 @@ import { mockMutation, setUpTest, waitForMutation } from '../test/utils.js';
 import {
   buildDeleteCurrentMemberRoute,
   buildPatchCurrentMemberRoute,
-  buildPatchMemberPasswordRoute,
   buildPostMemberPasswordRoute,
   buildUploadAvatarRoute,
 } from './routes.js';
@@ -328,68 +327,6 @@ describe('Member Mutations', () => {
 
       expect(mockedNotifier).toHaveBeenCalledWith(
         expect.objectContaining({ type: uploadAvatarRoutine.FAILURE }),
-      );
-    });
-  });
-
-  describe('useUpdatePassword', () => {
-    const route = `/${buildPatchMemberPasswordRoute()}`;
-    const mutation = mutations.useUpdatePassword;
-    const password = 'ASDasd123';
-    const currentPassword = 'ASDasd123';
-
-    it(`Update password`, async () => {
-      const endpoints = [
-        {
-          route,
-          response: {},
-          statusCode: StatusCodes.NO_CONTENT,
-          method: HttpMethod.Patch,
-        },
-      ];
-
-      const mockedMutation = await mockMutation({
-        endpoints,
-        mutation,
-        wrapper,
-      });
-
-      await act(async () => {
-        mockedMutation.mutate({ currentPassword, password });
-        await waitForMutation();
-      });
-
-      expect(mockedNotifier).toHaveBeenCalledWith({
-        type: updatePasswordRoutine.SUCCESS,
-        payload: { message: 'UPDATE_PASSWORD' },
-      });
-    });
-
-    it(`Unauthorized`, async () => {
-      const endpoints = [
-        {
-          route,
-          response: UNAUTHORIZED_RESPONSE,
-          method: HttpMethod.Patch,
-          statusCode: StatusCodes.UNAUTHORIZED,
-        },
-      ];
-
-      const mockedMutation = await mockMutation({
-        endpoints,
-        mutation,
-        wrapper,
-      });
-
-      await act(async () => {
-        mockedMutation.mutate({ password, currentPassword });
-        await waitForMutation();
-      });
-
-      expect(mockedNotifier).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: updatePasswordRoutine.FAILURE,
-        }),
       );
     });
   });

--- a/src/query/member/mutations.test.ts
+++ b/src/query/member/mutations.test.ts
@@ -19,10 +19,9 @@ import { mockMutation, setUpTest, waitForMutation } from '../test/utils.js';
 import {
   buildDeleteCurrentMemberRoute,
   buildPatchCurrentMemberRoute,
-  buildPostMemberPasswordRoute,
   buildUploadAvatarRoute,
 } from './routes.js';
-import { updatePasswordRoutine, uploadAvatarRoutine } from './routines.js';
+import { uploadAvatarRoutine } from './routines.js';
 
 const mockedNotifier = vi.fn();
 const { wrapper, queryClient, mutations } = setUpTest({
@@ -327,67 +326,6 @@ describe('Member Mutations', () => {
 
       expect(mockedNotifier).toHaveBeenCalledWith(
         expect.objectContaining({ type: uploadAvatarRoutine.FAILURE }),
-      );
-    });
-  });
-
-  describe('useCreatePassword', () => {
-    const route = `/${buildPostMemberPasswordRoute()}`;
-    const mutation = mutations.useCreatePassword;
-    const password = 'ASDasd123';
-
-    it(`Update password`, async () => {
-      const endpoints = [
-        {
-          route,
-          response: {},
-          statusCode: StatusCodes.NO_CONTENT,
-          method: HttpMethod.Post,
-        },
-      ];
-
-      const mockedMutation = await mockMutation({
-        endpoints,
-        mutation,
-        wrapper,
-      });
-
-      await act(async () => {
-        mockedMutation.mutate({ password });
-        await waitForMutation();
-      });
-
-      expect(mockedNotifier).toHaveBeenCalledWith({
-        type: updatePasswordRoutine.SUCCESS,
-        payload: { message: 'UPDATE_PASSWORD' },
-      });
-    });
-
-    it(`Unauthorized`, async () => {
-      const endpoints = [
-        {
-          route,
-          response: UNAUTHORIZED_RESPONSE,
-          method: HttpMethod.Post,
-          statusCode: StatusCodes.UNAUTHORIZED,
-        },
-      ];
-
-      const mockedMutation = await mockMutation({
-        endpoints,
-        mutation,
-        wrapper,
-      });
-
-      await act(async () => {
-        mockedMutation.mutate({ password });
-        await waitForMutation();
-      });
-
-      expect(mockedNotifier).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: updatePasswordRoutine.FAILURE,
-        }),
       );
     });
   });

--- a/src/query/member/mutations.ts
+++ b/src/query/member/mutations.ts
@@ -149,31 +149,6 @@ export default (queryConfig: QueryClientConfig) => {
   };
 
   /**
-   * Mutation to update the member password
-   * @param {Password} password new password that user wants to set
-   * @param {Password} currentPassword current password already stored, needs to match old password
-   */
-  const useUpdatePassword = () =>
-    useMutation({
-      mutationFn: (payload: {
-        password: Password;
-        currentPassword: Password;
-      }) => Api.updatePassword(payload),
-      onSuccess: () => {
-        notifier?.({
-          type: updatePasswordRoutine.SUCCESS,
-          payload: { message: 'UPDATE_PASSWORD' },
-        });
-      },
-      onError: (error: Error) => {
-        notifier?.({
-          type: updatePasswordRoutine.FAILURE,
-          payload: { error },
-        });
-      },
-    });
-
-  /**
    * Mutation to create a member password
    * @param {Password} password new password to set on current member
    */
@@ -244,7 +219,6 @@ export default (queryConfig: QueryClientConfig) => {
      * @deprecated use useEditCurrentMember
      */
     useEditMember: useEditCurrentMember,
-    useUpdatePassword,
     useCreatePassword,
     useUpdateMemberEmail,
     useValidateEmailUpdate,

--- a/src/query/member/mutations.ts
+++ b/src/query/member/mutations.ts
@@ -2,7 +2,6 @@ import {
   CompleteMember,
   CurrentAccount,
   MAX_THUMBNAIL_SIZE,
-  Password,
 } from '@graasp/sdk';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -15,7 +14,6 @@ import {
   deleteCurrentMemberRoutine,
   editMemberRoutine,
   updateEmailRoutine,
-  updatePasswordRoutine,
   uploadAvatarRoutine,
 } from './routines.js';
 
@@ -148,35 +146,6 @@ export default (queryConfig: QueryClientConfig) => {
     });
   };
 
-  /**
-   * Mutation to create a member password
-   * @param {Password} password new password to set on current member
-   */
-  const useCreatePassword = () => {
-    const queryClient = useQueryClient();
-    return useMutation({
-      mutationFn: (payload: { password: Password }) =>
-        Api.createPassword(payload),
-      onSuccess: () => {
-        notifier?.({
-          type: updatePasswordRoutine.SUCCESS,
-          payload: { message: 'UPDATE_PASSWORD' },
-        });
-      },
-      onError: (error: Error) => {
-        notifier?.({
-          type: updatePasswordRoutine.FAILURE,
-          payload: { error },
-        });
-      },
-      onSettled: () => {
-        queryClient.invalidateQueries({
-          queryKey: memberKeys.current().passwordStatus,
-        });
-      },
-    });
-  };
-
   const useUpdateMemberEmail = () =>
     useMutation({
       mutationFn: (newEmail: string) => Api.updateEmail(newEmail),
@@ -219,7 +188,6 @@ export default (queryConfig: QueryClientConfig) => {
      * @deprecated use useEditCurrentMember
      */
     useEditMember: useEditCurrentMember,
-    useCreatePassword,
     useUpdateMemberEmail,
     useValidateEmailUpdate,
   };

--- a/src/query/member/routines.ts
+++ b/src/query/member/routines.ts
@@ -7,5 +7,4 @@ export const deleteCurrentMemberRoutine = createRoutine(
   'DELETE_CURRENT_MEMBER',
 );
 export const uploadAvatarRoutine = createRoutine('UPLOAD_AVATAR');
-export const updatePasswordRoutine = createRoutine('UPDATE_PASSWORD');
 export const updateEmailRoutine = createRoutine('UPDATE_EMAIL');


### PR DESCRIPTION
I replace the `updatePassword` and `createPassword` endpoints to avoid using `notifier`.

ref #819 