### PR TITLE
feat: use export member data generation, remove notification

### DIFF
--- a/src/config/notifier.ts
+++ b/src/config/notifier.ts
@@ -13,7 +13,6 @@ const {
   postPublicProfileRoutine,
   patchPublicProfileRoutine,
   updateEmailRoutine,
-  exportMemberDataRoutine,
   getInvitationRoutine,
 } = routines;
 
@@ -63,8 +62,7 @@ export default ({
     case updatePasswordRoutine.FAILURE:
     case postPublicProfileRoutine.FAILURE:
     case updateEmailRoutine.FAILURE:
-    case patchPublicProfileRoutine.FAILURE:
-    case exportMemberDataRoutine.FAILURE: {
+    case patchPublicProfileRoutine.FAILURE: {
       message = getErrorMessageFromPayload(payload);
       break;
     }
@@ -74,8 +72,7 @@ export default ({
     case updatePasswordRoutine.SUCCESS:
     case postPublicProfileRoutine.SUCCESS:
     case updateEmailRoutine.SUCCESS:
-    case patchPublicProfileRoutine.SUCCESS:
-    case exportMemberDataRoutine.SUCCESS: {
+    case patchPublicProfileRoutine.SUCCESS: {
       message = getSuccessMessageFromPayload(payload);
       break;
     }

--- a/src/locales/fr/account.json
+++ b/src/locales/fr/account.json
@@ -98,7 +98,7 @@
   "EXPORT_INFORMATIONS_TITLE": "Télécharger une copie de vos données",
   "EXPORT_INFORMATIONS_DESCRIPTION": "Vous pouvez télécharger une copie de vos données.",
   "EXPORT_INFORMATIONS_BUTTON_TEXT": "Télécharger vos données",
-  "EXPORT_SUCCESS_MESSAGE": "Vous avez demandé vos données avec succès. Vous recevrez un e-mail avec vos données dans quelques minutes",
+  "EXPORT_SUCCESS_MESSAGE": "Vous avez demandé vos données avec succès. Vous recevrez un e-mail avec vos données dans quelques minutes.",
   "EXPORT_ERROR_MESSAGE": "Une erreur inattendue est survenue",
   "NOT_FOUND_PAGE_TEXT": "Page non trouvée",
   "NOT_FOUND_PAGE_MESSAGE": "Désolé, nous n'avons pas pu trouver cette page.",

--- a/src/modules/account/settings/ExportMemberData.tsx
+++ b/src/modules/account/settings/ExportMemberData.tsx
@@ -1,21 +1,27 @@
 import { type JSX, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Stack, Typography } from '@mui/material';
+import { Alert, Stack, Typography } from '@mui/material';
+
+import { useMutation } from '@tanstack/react-query';
 
 import { BorderedSection } from '@/components/layout/BorderedSection';
 import { Button } from '@/components/ui/Button';
 import { NS } from '@/config/constants';
-import { mutations } from '@/config/queryClient';
 import { EXPORT_DATA_BUTTON_ID } from '@/config/selectors';
+import { exportMemberDataMutation } from '@/openapi/client/@tanstack/react-query.gen';
 
 export function ExportMemberData(): JSX.Element {
   const { t } = useTranslation(NS.Account);
 
   const [isExported, setIsExported] = useState(false);
-  const { mutate: exportData } = mutations.useExportMemberData();
+  const {
+    mutate: exportData,
+    isSuccess,
+    isError,
+  } = useMutation(exportMemberDataMutation());
   const onClick = () => {
-    exportData();
+    exportData({});
     setIsExported(true);
   };
 
@@ -25,6 +31,10 @@ export function ExportMemberData(): JSX.Element {
         <Typography variant="body2">
           {t('EXPORT_INFORMATIONS_DESCRIPTION')}
         </Typography>
+        {isSuccess && (
+          <Alert severity="success">{t('EXPORT_SUCCESS_MESSAGE')}</Alert>
+        )}
+        {isError && <Alert severity="error">{t('EXPORT_ERROR_MESSAGE')}</Alert>}
         <Button
           onClick={onClick}
           disabled={isExported}

--- a/src/query/member/mutations.test.ts
+++ b/src/query/member/mutations.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@graasp/sdk';
 
 import { act } from '@testing-library/react';
-import { ReasonPhrases, StatusCodes } from 'http-status-codes';
+import { StatusCodes } from 'http-status-codes';
 import nock from 'nock';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -18,17 +18,12 @@ import { OK_RESPONSE, UNAUTHORIZED_RESPONSE } from '../test/constants.js';
 import { mockMutation, setUpTest, waitForMutation } from '../test/utils.js';
 import {
   buildDeleteCurrentMemberRoute,
-  buildExportMemberDataRoute,
   buildPatchCurrentMemberRoute,
   buildPatchMemberPasswordRoute,
   buildPostMemberPasswordRoute,
   buildUploadAvatarRoute,
 } from './routes.js';
-import {
-  exportMemberDataRoutine,
-  updatePasswordRoutine,
-  uploadAvatarRoutine,
-} from './routines.js';
+import { updatePasswordRoutine, uploadAvatarRoutine } from './routines.js';
 
 const mockedNotifier = vi.fn();
 const { wrapper, queryClient, mutations } = setUpTest({
@@ -457,33 +452,6 @@ describe('Member Mutations', () => {
           type: updatePasswordRoutine.FAILURE,
         }),
       );
-    });
-  });
-
-  describe('useExportMemberData', () => {
-    const mutation = mutations.useExportMemberData;
-    const response = ReasonPhrases.OK;
-    it('Export member data', async () => {
-      const endpoints = [
-        {
-          response,
-          route: `/${buildExportMemberDataRoute()}`,
-          method: HttpMethod.Post,
-        },
-      ];
-      const mockedMutation = await mockMutation({
-        endpoints,
-        mutation,
-        wrapper,
-      });
-      await act(async () => {
-        mockedMutation.mutate();
-        await waitForMutation();
-      });
-
-      expect(mockedNotifier).toHaveBeenCalledWith({
-        type: exportMemberDataRoutine.SUCCESS,
-      });
     });
   });
 });

--- a/src/query/member/mutations.ts
+++ b/src/query/member/mutations.ts
@@ -14,7 +14,6 @@ import * as Api from './api.js';
 import {
   deleteCurrentMemberRoutine,
   editMemberRoutine,
-  exportMemberDataRoutine,
   updateEmailRoutine,
   updatePasswordRoutine,
   uploadAvatarRoutine,
@@ -237,21 +236,6 @@ export default (queryConfig: QueryClientConfig) => {
       },
     });
 
-  const useExportMemberData = () =>
-    useMutation({
-      mutationFn: () => Api.exportMemberData(),
-      onSuccess: () => {
-        notifier?.({
-          type: exportMemberDataRoutine.SUCCESS,
-        });
-      },
-      onError: (error: Error) => {
-        notifier?.({
-          type: exportMemberDataRoutine.FAILURE,
-          payload: { error },
-        });
-      },
-    });
   return {
     useDeleteCurrentMember,
     useUploadAvatar,
@@ -264,6 +248,5 @@ export default (queryConfig: QueryClientConfig) => {
     useCreatePassword,
     useUpdateMemberEmail,
     useValidateEmailUpdate,
-    useExportMemberData,
   };
 };

--- a/src/query/member/routines.ts
+++ b/src/query/member/routines.ts
@@ -9,4 +9,3 @@ export const deleteCurrentMemberRoutine = createRoutine(
 export const uploadAvatarRoutine = createRoutine('UPLOAD_AVATAR');
 export const updatePasswordRoutine = createRoutine('UPDATE_PASSWORD');
 export const updateEmailRoutine = createRoutine('UPDATE_EMAIL');
-export const exportMemberDataRoutine = createRoutine('EXPORT_DATA');


### PR DESCRIPTION
I removed the `exportData` mutation to use the generated one. I removed the use of the notifier, showing alert instead.