### PR TITLE
fix: use language query string when present

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -23,9 +23,14 @@ i18n
     supportedLngs: ['fr', 'de', 'it', 'es', 'ar', 'en'],
     // options for the language detector
     detection: {
+      // The priority order is defined as:
+      // 1. querystring: users coming from an external link may want to see the page in the language set by the link
+      // 2. localstorage: users that have an item in their localstorage (already visited the page with an account)
+      // 3. navigator: use the the user preferred interface language as a last resort.
       order: ['querystring', 'localStorage', 'navigator'],
+      // store the language in the localstorage for persistance
       caches: ['localStorage'],
-      // the name of the query parameter to look for the language
+      // the name of the query parameter to look for the language (default: lng)
       lookupQuerystring: 'lang',
     },
     react: {

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -23,8 +23,10 @@ i18n
     supportedLngs: ['fr', 'de', 'it', 'es', 'ar', 'en'],
     // options for the language detector
     detection: {
-      order: ['localStorage', 'navigator', 'querystring'],
+      order: ['querystring', 'localStorage', 'navigator'],
       caches: ['localStorage'],
+      // the name of the query parameter to look for the language
+      lookupQuerystring: 'lang',
     },
     react: {
       // prevent the translations from using the react suspense and thus making the interface flicker


### PR DESCRIPTION
In this PR I update the language detection priority so the language query string is considered before the local storage or the navigator.

This allows urls from the documentation to specify for example: `http://graasp.org/auth/register?lang=fr` and the register page will be in french.