### PR TITLE
fix: show error notifications on file upload

### DIFF
--- a/cypress/e2e/player/hidden.cy.ts
+++ b/cypress/e2e/player/hidden.cy.ts
@@ -18,7 +18,7 @@ const parentItem = PackedFolderItemFactory({
 });
 const FOLDER_WITH_HIDDEN_ITEMS: ItemForTest[] = [
   parentItem,
-  DocumentItemFactory({ parentItem }),
+  DocumentItemFactory({ parentItem, settings: { isCollapsible: false } }),
   PackedDocumentItemFactory(
     { parentItem, settings: { isCollapsible: false } },
     { hiddenVisibility: {} },

--- a/cypress/e2e/player/hidden.cy.ts
+++ b/cypress/e2e/player/hidden.cy.ts
@@ -19,13 +19,17 @@ const parentItem = PackedFolderItemFactory({
 const FOLDER_WITH_HIDDEN_ITEMS: ItemForTest[] = [
   parentItem,
   DocumentItemFactory({ parentItem }),
-  PackedDocumentItemFactory({ parentItem }, { hiddenVisibility: {} }),
+  PackedDocumentItemFactory(
+    { parentItem, settings: { isCollapsible: false } },
+    { hiddenVisibility: {} },
+  ),
   PackedDocumentItemFactory(
     {
       name: 'hidden document',
       settings: {
         isPinned: false,
         showChatbox: false,
+        isCollapsible: false,
       },
       parentItem,
     },

--- a/src/config/notifier.ts
+++ b/src/config/notifier.ts
@@ -77,12 +77,12 @@ export default ({
   }
 };
 
-export const getErrorMessage = (e: unknown, defaultValue?: string) => {
+export const getErrorMessage = (e: unknown) => {
   if (e instanceof AxiosError) {
     return e.response?.data?.message;
   } else if (e instanceof Error) {
     return e.message;
   }
 
-  return defaultValue ?? 'UNEXPECTED_ERROR';
+  return null;
 };

--- a/src/config/notifier.ts
+++ b/src/config/notifier.ts
@@ -1,6 +1,6 @@
 import { toast } from 'react-toastify';
 
-import { isAxiosError } from 'axios';
+import { AxiosError, isAxiosError } from 'axios';
 
 import { MessageKeys } from '@/@types/i18next';
 import { Notifier, routines } from '@/query';
@@ -75,4 +75,17 @@ export default ({
   else if (message) {
     toast.success(translate(message, { ns: NS.Messages }));
   }
+};
+
+export const getCatchErrorMessage = (e: unknown, defaultValue?: string) => {
+  console.log(e);
+  if (e instanceof AxiosError) {
+    console.log('tzhrgfe');
+    return e.response?.data?.message;
+  } else if (e instanceof Error) {
+    console.log('wefjkl');
+    return e.message;
+  }
+
+  return defaultValue ?? 'UNEXPECTED_ERROR';
 };

--- a/src/config/notifier.ts
+++ b/src/config/notifier.ts
@@ -77,13 +77,10 @@ export default ({
   }
 };
 
-export const getCatchErrorMessage = (e: unknown, defaultValue?: string) => {
-  console.log(e);
+export const getErrorMessage = (e: unknown, defaultValue?: string) => {
   if (e instanceof AxiosError) {
-    console.log('tzhrgfe');
     return e.response?.data?.message;
   } else if (e instanceof Error) {
-    console.log('wefjkl');
     return e.message;
   }
 

--- a/src/locales/ar/builder.json
+++ b/src/locales/ar/builder.json
@@ -67,7 +67,7 @@
   "DOWNLOAD_ITEM_BUTTON": "تحميل",
   "DROP_DOWN_PLACEHOLDER": "الرجاء الاختيار من القائمة",
   "DROPZONE_HELPER_TEXT": "قم بإسقاط ملفاتك هنا للتحميل",
-  "DROPZONE_HELPER_LIMIT_REMINDER_TEXT": "الحد الأقصى 15 ملفًا بحجم 1 جيجابايت",
+  "DROPZONE_HELPER_LIMIT_REMINDER_TEXT": "الحد الأقصى {{max}} ملفًا بحجم 1 جيجابايت",
   "DROPZONE_HELPER_ACTION": "تصفح ملفات",
   "DROPZONE_HELPER_OPTIONAL_ACTION_TEXT": "أو",
   "DESCRIPTION_LABEL": "وصف",

--- a/src/locales/ar/builder.json
+++ b/src/locales/ar/builder.json
@@ -67,7 +67,6 @@
   "DOWNLOAD_ITEM_BUTTON": "تحميل",
   "DROP_DOWN_PLACEHOLDER": "الرجاء الاختيار من القائمة",
   "DROPZONE_HELPER_TEXT": "قم بإسقاط ملفاتك هنا للتحميل",
-  "DROPZONE_HELPER_LIMIT_REMINDER_TEXT": "الحد الأقصى {{max}} ملفًا بحجم 1 جيجابايت",
   "DROPZONE_HELPER_ACTION": "تصفح ملفات",
   "DROPZONE_HELPER_OPTIONAL_ACTION_TEXT": "أو",
   "DESCRIPTION_LABEL": "وصف",

--- a/src/locales/ar/messages.json
+++ b/src/locales/ar/messages.json
@@ -41,7 +41,6 @@
   "INVALID_DOWNLOAD_PARAMETERS": "واحد أو أكثر من معلمات التنزيل غير صالحة",
   "LOCAL_FILE_NOT_FOUND": "لم يتم العثور على الملف المحلي",
   "S3_FILE_NOT_FOUND": "لم يتم العثور على ملف S3",
-  "UPLOAD_FILE_UNEXPECTED_ERROR": "حدث خطأ غير متوقع أثناء تحميل ملف",
   "DOWNLOAD_FILE_UNEXPECTED_ERROR": "حدث خطأ غير متوقع أثناء تنزيل ملف",
   "RESTORE_ITEMS": "لقد نجحت في استعادة العنصر (العناصر)",
   "CREATE_ITEM": "تم إنشاء العنصر بنجاح",

--- a/src/locales/de/builder.json
+++ b/src/locales/de/builder.json
@@ -67,7 +67,7 @@
   "DOWNLOAD_ITEM_BUTTON": "Download",
   "DROP_DOWN_PLACEHOLDER": "Bitte wählen Sie aus der Liste",
   "DROPZONE_HELPER_TEXT": "Legen Sie Ihre Dateien zum Hochladen hier ab",
-  "DROPZONE_HELPER_LIMIT_REMINDER_TEXT": "Maximal 15 Dateien mit 1 GB",
+  "DROPZONE_HELPER_LIMIT_REMINDER_TEXT": "Maximal {{max}} Dateien mit 1 GB",
   "DROPZONE_HELPER_ACTION": "Dateien durchsuchen",
   "DROPZONE_HELPER_OPTIONAL_ACTION_TEXT": "oder",
   "DESCRIPTION_LABEL": "Beschreibung",

--- a/src/locales/de/builder.json
+++ b/src/locales/de/builder.json
@@ -67,7 +67,6 @@
   "DOWNLOAD_ITEM_BUTTON": "Download",
   "DROP_DOWN_PLACEHOLDER": "Bitte wählen Sie aus der Liste",
   "DROPZONE_HELPER_TEXT": "Legen Sie Ihre Dateien zum Hochladen hier ab",
-  "DROPZONE_HELPER_LIMIT_REMINDER_TEXT": "Maximal {{max}} Dateien mit 1 GB",
   "DROPZONE_HELPER_ACTION": "Dateien durchsuchen",
   "DROPZONE_HELPER_OPTIONAL_ACTION_TEXT": "oder",
   "DESCRIPTION_LABEL": "Beschreibung",

--- a/src/locales/de/messages.json
+++ b/src/locales/de/messages.json
@@ -41,7 +41,7 @@
   "INVALID_DOWNLOAD_PARAMETERS": "Einer oder mehrere Download-Parameter sind ungültig",
   "LOCAL_FILE_NOT_FOUND": "Die lokale Datei wurde nicht gefunden",
   "S3_FILE_NOT_FOUND": "Die S3-Datei wurde nicht gefunden",
-  "UPLOAD_FILE_UNEXPECTED_ERROR": "Beim Hochladen einer Datei ist ein unerwarteter Fehler aufgetreten",
+  "UPLOAD_FILE_UNEXPECTED_ERROR": "Beim Hochladen Dateien ist ein unerwarteter Fehler aufgetreten",
   "DOWNLOAD_FILE_UNEXPECTED_ERROR": "Beim Herunterladen einer Datei ist ein unerwarteter Fehler aufgetreten",
   "RESTORE_ITEMS": "Sie haben die Elemente erfolgreich wiederhergestellt",
   "CREATE_ITEM": "Das Element wurde erfolgreich erstellt",

--- a/src/locales/en/builder.json
+++ b/src/locales/en/builder.json
@@ -7,7 +7,7 @@
     "RETURN_HOME": "Home"
   },
   "FILE_UPLOADER": {
-    "ERROR_WRAPPER": "Some files might have not been uploaded because of the following reason: {{error}}"
+    "ERROR_WRAPPER": "Some files were not uploaded because of the following error: {{error}}"
   },
   "REDIRECTION_TEXT": "Redirection",
   "REDIRECTION_BUTTON": "Navigate to redirection",
@@ -72,7 +72,7 @@
   "DOWNLOAD_ITEM_BUTTON": "Download",
   "DROP_DOWN_PLACEHOLDER": "Please Choose From List",
   "DROPZONE_HELPER_TEXT": "Drop your files here to upload",
-  "DROPZONE_HELPER_LIMIT_REMINDER_TEXT": "Max 15 files of 1GB",
+  "DROPZONE_HELPER_LIMIT_REMINDER_TEXT": "Max {{max}} files of 1GB",
   "DROPZONE_HELPER_TUTORIALS": "Where should you start? Click here for more information",
   "DROPZONE_HELPER_ACTION": "Browse Files",
   "DROPZONE_HELPER_OPTIONAL_ACTION_TEXT": "or",

--- a/src/locales/en/builder.json
+++ b/src/locales/en/builder.json
@@ -6,6 +6,9 @@
     "RECYCLED_ITEMS": "Trash",
     "RETURN_HOME": "Home"
   },
+  "FILE_UPLOADER": {
+    "ERROR_WRAPPER": "Some files might have not been uploaded because of the following reason: {{error}}"
+  },
   "REDIRECTION_TEXT": "Redirection",
   "REDIRECTION_BUTTON": "Navigate to redirection",
   "AVATAR_DEFAULT_ALT": "avatar",

--- a/src/locales/en/builder.json
+++ b/src/locales/en/builder.json
@@ -7,7 +7,7 @@
     "RETURN_HOME": "Home"
   },
   "FILE_UPLOADER": {
-    "ERROR_WRAPPER": "Some files were not uploaded because of the following error: {{error}}"
+    "GENERAL_ERROR": "Some files could not be uploaded, please fix the issue and try again."
   },
   "REDIRECTION_TEXT": "Redirection",
   "REDIRECTION_BUTTON": "Navigate to redirection",

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -41,7 +41,7 @@
   "INVALID_DOWNLOAD_PARAMETERS": "One or many download parameters are invalid",
   "LOCAL_FILE_NOT_FOUND": "The local file is not found",
   "S3_FILE_NOT_FOUND": "The S3 file is not found",
-  "UPLOAD_FILE_UNEXPECTED_ERROR": "An unexpected error happened while uploading a file",
+  "UPLOAD_FILES_UNEXPECTED_ERROR": "An unexpected error happened while uploading files",
   "DOWNLOAD_FILE_UNEXPECTED_ERROR": "An unexpected error happened while downloading a file",
   "RESTORE_ITEMS": "You successfully restored the item(s)",
   "CREATE_ITEM": "The item was successfully created",

--- a/src/locales/es/builder.json
+++ b/src/locales/es/builder.json
@@ -58,7 +58,7 @@
   "DOWNLOAD_ITEM_BUTTON": "Descargar",
   "DROP_DOWN_PLACEHOLDER": "Por favor elija de la lista",
   "DROPZONE_HELPER_TEXT": "Deja tus archivos aquí para subirlos",
-  "DROPZONE_HELPER_LIMIT_REMINDER_TEXT": "Máximo 15 archivos de 1 GB",
+  "DROPZONE_HELPER_LIMIT_REMINDER_TEXT": "Máximo {{max}} archivos de 1 GB",
   "DROPZONE_HELPER_ACTION": "Búsqueda de archivos",
   "DROPZONE_HELPER_OPTIONAL_ACTION_TEXT": "o",
   "DESCRIPTION_LABEL": "Descripción",

--- a/src/locales/es/builder.json
+++ b/src/locales/es/builder.json
@@ -58,7 +58,6 @@
   "DOWNLOAD_ITEM_BUTTON": "Descargar",
   "DROP_DOWN_PLACEHOLDER": "Por favor elija de la lista",
   "DROPZONE_HELPER_TEXT": "Deja tus archivos aquí para subirlos",
-  "DROPZONE_HELPER_LIMIT_REMINDER_TEXT": "Máximo {{max}} archivos de 1 GB",
   "DROPZONE_HELPER_ACTION": "Búsqueda de archivos",
   "DROPZONE_HELPER_OPTIONAL_ACTION_TEXT": "o",
   "DESCRIPTION_LABEL": "Descripción",

--- a/src/locales/es/messages.json
+++ b/src/locales/es/messages.json
@@ -41,7 +41,6 @@
   "INVALID_DOWNLOAD_PARAMETERS": "Uno o varios parámetros de descarga no son válidos",
   "LOCAL_FILE_NOT_FOUND": "No se encuentra el archivo local",
   "S3_FILE_NOT_FOUND": "No se encuentra el archivo S3",
-  "UPLOAD_FILE_UNEXPECTED_ERROR": "Se produjo un error inesperado al cargar un archivo",
   "DOWNLOAD_FILE_UNEXPECTED_ERROR": "Se produjo un error inesperado al descargar un archivo",
   "RESTORE_ITEMS": "Has restaurado exitosamente el(los) artículo(s)",
   "CREATE_ITEM": "El artículo se creó correctamente",

--- a/src/locales/fr/builder.json
+++ b/src/locales/fr/builder.json
@@ -68,7 +68,7 @@
   "DOWNLOAD_ITEM_BUTTON": "Télécharger",
   "DROP_DOWN_PLACEHOLDER": "Choisir dans la liste",
   "DROPZONE_HELPER_TEXT": "Déposez vos fichiers ici pour les téléverser",
-  "DROPZONE_HELPER_LIMIT_REMINDER_TEXT": "Maximum 15 fichiers de 1 Go chacun",
+  "DROPZONE_HELPER_LIMIT_REMINDER_TEXT": "Maximum {{max}} fichiers de 1 Go chacun",
   "DROPZONE_HELPER_TUTORIALS": "Par où commencer ? Cliquer ici pour plus d'informations",
   "DROPZONE_HELPER_ACTION": "Parcourir les fichiers",
   "DROPZONE_HELPER_OPTIONAL_ACTION_TEXT": "ou",

--- a/src/locales/fr/builder.json
+++ b/src/locales/fr/builder.json
@@ -6,6 +6,9 @@
     "RECYCLED_ITEMS": "Corbeille",
     "RETURN_HOME": "Accueil"
   },
+  "FILE_UPLOADER": {
+    "ERROR_WRAPPER": "Certains fichiers peuvent ne pas avoir été téléchargés à cause de la raison suivante : {{error}}"
+  },
   "REDIRECTION_TEXT": "Redirection",
   "REDIRECTION_BUTTON": "Accéder à la redirection",
   "AVATAR_DEFAULT_ALT": "avatar",

--- a/src/locales/fr/builder.json
+++ b/src/locales/fr/builder.json
@@ -7,7 +7,7 @@
     "RETURN_HOME": "Accueil"
   },
   "FILE_UPLOADER": {
-    "ERROR_WRAPPER": "Certains fichiers peuvent ne pas avoir été téléchargés à cause de la raison suivante : {{error}}"
+    "GENERAL_ERROR": "Certains fichiers n'ont pas pu être téléchargés, corrigez l'erreur et réessayez."
   },
   "REDIRECTION_TEXT": "Redirection",
   "REDIRECTION_BUTTON": "Accéder à la redirection",

--- a/src/locales/fr/messages.json
+++ b/src/locales/fr/messages.json
@@ -33,7 +33,7 @@
   "FILE_IS_NOT_IMAGE": "Le fichier n'est pas une image",
   "INVALID_UPLOAD_PARAMETERS": "Un ou plusieurs paramètres de téléchargement ne sont pas valides",
   "UPLOAD_EMPTY_FILE": "Impossible de télécharger un fichier vide",
-  "UPLOAD_TOO_MANY_FILES": "Impossible de télécharger trop de fichiers",
+  "UPLOAD_TOO_MANY_FILES": "Impossible de télécharger autant de fichiers",
   "UPLOAD_BIG_FILES": "Impossible de télécharger des fichiers volumineux",
   "INVALID_FILE_PATH_FOR_COPY": "Le chemin du fichier soumis n'est pas valide pour la copie",
   "INVALID_FILE_PATH_FOR_DELETE": "Le chemin du fichier soumis n'est pas valide pour la suppression",

--- a/src/locales/fr/messages.json
+++ b/src/locales/fr/messages.json
@@ -41,7 +41,7 @@
   "INVALID_DOWNLOAD_PARAMETERS": "Un ou plusieurs paramètres de téléchargement ne sont pas valides",
   "LOCAL_FILE_NOT_FOUND": "Le fichier local n'est pas trouvé",
   "S3_FILE_NOT_FOUND": "Le fichier S3 n'est pas trouvé",
-  "UPLOAD_FILE_UNEXPECTED_ERROR": "Une erreur inattendue s'est produite lors du téléchargement d'un fichier",
+  "UPLOAD_FILE_UNEXPECTED_ERROR": "Une erreur inattendue s'est produite lors du téléchargement de fichiers",
   "DOWNLOAD_FILE_UNEXPECTED_ERROR": "Une erreur inattendue s'est produite lors du téléchargement d'un fichier",
   "RESTORE_ITEMS": "Vous avez restauré avec succès le(s) élément(s)",
   "CREATE_ITEM": "L'élément a été créé avec succès",

--- a/src/locales/it/builder.json
+++ b/src/locales/it/builder.json
@@ -67,7 +67,7 @@
   "DOWNLOAD_ITEM_BUTTON": "Download",
   "DROP_DOWN_PLACEHOLDER": "Si prega di scegliere dall'elenco",
   "DROPZONE_HELPER_TEXT": "Trascina qui i tuoi file per caricarli",
-  "DROPZONE_HELPER_LIMIT_REMINDER_TEXT": "Massimo 15 file da 1 GB",
+  "DROPZONE_HELPER_LIMIT_REMINDER_TEXT": "Massimo {{max}} file da 1 GB",
   "DROPZONE_HELPER_ACTION": "Sfoglia file",
   "DROPZONE_HELPER_OPTIONAL_ACTION_TEXT": "O",
   "DESCRIPTION_LABEL": "Descrizione",

--- a/src/locales/it/messages.json
+++ b/src/locales/it/messages.json
@@ -41,7 +41,6 @@
   "INVALID_DOWNLOAD_PARAMETERS": "Uno o più parametri di download non sono validi",
   "LOCAL_FILE_NOT_FOUND": "Il file locale non è stato trovato",
   "S3_FILE_NOT_FOUND": "Il file S3 non è stato trovato",
-  "UPLOAD_FILE_UNEXPECTED_ERROR": "Si è verificato un errore imprevisto durante il caricamento di un file",
   "DOWNLOAD_FILE_UNEXPECTED_ERROR": "Si è verificato un errore imprevisto durante il download di un file",
   "RESTORE_ITEMS": "Hai ripristinato correttamente gli elementi",
   "CREATE_ITEM": "L'articolo è stato creato con successo",

--- a/src/modules/builder/components/file/FileUploader.tsx
+++ b/src/modules/builder/components/file/FileUploader.tsx
@@ -122,7 +122,15 @@ export function FileUploader({
         uploadProgress={Math.ceil(totalProgress * 100)}
         multiple
         onDrop={onDrop}
-        error={error ? t('FILE_UPLOADER.ERROR_WRAPPER', { error }) : undefined}
+        error={
+          error ? (
+            <>
+              {error}
+              <br />
+              {t('FILE_UPLOADER.GENERAL_ERROR')}
+            </>
+          ) : undefined
+        }
         buttonText={t('DROPZONE_HELPER_ACTION')}
         hints={hints}
         buttons={buttons}

--- a/src/modules/builder/components/file/FileUploader.tsx
+++ b/src/modules/builder/components/file/FileUploader.tsx
@@ -11,7 +11,7 @@ import { HelpCircleIcon } from 'lucide-react';
 
 import { CustomLink } from '@/components/ui/CustomLink';
 import { NS } from '@/config/constants';
-import { getCatchErrorMessage } from '@/config/notifier';
+import { getErrorMessage } from '@/config/notifier';
 import { mutations } from '@/config/queryClient';
 import { useButtonColor } from '@/ui/buttons/hooks';
 import FileDropper from '@/ui/upload/FileDropper/FileDropper';
@@ -79,7 +79,7 @@ export function FileUploader({
       });
       onComplete?.();
     } catch (e) {
-      const message = getCatchErrorMessage(e, 'UPLOAD_FILES_UNEXPECTED_ERROR');
+      const message = getErrorMessage(e, 'UPLOAD_FILES_UNEXPECTED_ERROR');
       setError(translateMessage(message));
 
       if (e instanceof Error) {

--- a/src/modules/builder/components/file/FileUploader.tsx
+++ b/src/modules/builder/components/file/FileUploader.tsx
@@ -79,8 +79,11 @@ export function FileUploader({
       });
       onComplete?.();
     } catch (e) {
-      const message = getErrorMessage(e, 'UPLOAD_FILES_UNEXPECTED_ERROR');
-      setError(translateMessage(message));
+      const message = getErrorMessage(e);
+      setError(
+        translateMessage(message) ??
+          translateMessage('UPLOAD_FILES_UNEXPECTED_ERROR'),
+      );
 
       if (e instanceof Error) {
         onError?.(e);

--- a/src/modules/builder/components/hooks/uploadWithProgress.ts
+++ b/src/modules/builder/components/hooks/uploadWithProgress.ts
@@ -38,6 +38,7 @@ export const useUploadWithProgress = (): {
   const close = (error?: unknown) => {
     // show correct feedback message
     if (error) {
+      console.error(error);
       toast.error(
         translateMessage(
           getErrorMessage(error, 'UPLOAD_FILES_UNEXPECTED_ERROR'),

--- a/src/modules/builder/components/hooks/uploadWithProgress.ts
+++ b/src/modules/builder/components/hooks/uploadWithProgress.ts
@@ -40,9 +40,8 @@ export const useUploadWithProgress = (): {
     if (error) {
       console.error(error);
       toast.error(
-        translateMessage(
-          getErrorMessage(error, 'UPLOAD_FILES_UNEXPECTED_ERROR'),
-        ),
+        translateMessage(getErrorMessage(error)) ??
+          translateMessage('UPLOAD_FILES_UNEXPECTED_ERROR'),
       );
     } else if (toastId.current) {
       toast.done(toastId.current);

--- a/src/modules/builder/components/hooks/uploadWithProgress.ts
+++ b/src/modules/builder/components/hooks/uploadWithProgress.ts
@@ -5,7 +5,7 @@ import { Id, toast } from 'react-toastify';
 import { AxiosProgressEvent } from 'axios';
 
 import { NS } from '@/config/constants';
-import { getCatchErrorMessage } from '@/config/notifier';
+import { getErrorMessage } from '@/config/notifier';
 
 export const useUploadWithProgress = (): {
   update: (p: AxiosProgressEvent) => void;
@@ -40,7 +40,7 @@ export const useUploadWithProgress = (): {
     if (error) {
       toast.error(
         translateMessage(
-          getCatchErrorMessage(error, 'UPLOAD_FILES_UNEXPECTED_ERROR'),
+          getErrorMessage(error, 'UPLOAD_FILES_UNEXPECTED_ERROR'),
         ),
       );
     } else if (toastId.current) {

--- a/src/modules/builder/components/hooks/uploadWithProgress.ts
+++ b/src/modules/builder/components/hooks/uploadWithProgress.ts
@@ -5,13 +5,15 @@ import { Id, toast } from 'react-toastify';
 import { AxiosProgressEvent } from 'axios';
 
 import { NS } from '@/config/constants';
+import { getCatchErrorMessage } from '@/config/notifier';
 
 export const useUploadWithProgress = (): {
   update: (p: AxiosProgressEvent) => void;
-  close: (e?: Error) => void;
+  close: (e?: unknown) => void;
   show: (p?: number) => void;
 } => {
   const { t: translateBuilder } = useTranslation(NS.Builder);
+  const { t: translateMessage } = useTranslation(NS.Messages);
 
   // we need to keep a reference of the toastId to be able to update it
   const toastId = useRef<Id | null>(null);
@@ -33,10 +35,14 @@ export const useUploadWithProgress = (): {
     }
   };
 
-  const close = (error?: Error) => {
+  const close = (error?: unknown) => {
     // show correct feedback message
     if (error) {
-      toast.error(error.message);
+      toast.error(
+        translateMessage(
+          getCatchErrorMessage(error, 'UPLOAD_FILES_UNEXPECTED_ERROR'),
+        ),
+      );
     } else if (toastId.current) {
       toast.done(toastId.current);
     }

--- a/src/modules/builder/components/item/form/file/UploadFileModalContent.tsx
+++ b/src/modules/builder/components/item/form/file/UploadFileModalContent.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react';
+import { type JSX } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DialogActions, DialogContent, DialogTitle } from '@mui/material';

--- a/src/modules/builder/components/main/ImportH5P.tsx
+++ b/src/modules/builder/components/main/ImportH5P.tsx
@@ -55,9 +55,7 @@ const ImportH5P = ({
         closeNotification();
         onClose?.();
       } catch (error) {
-        if (error instanceof Error) {
-          closeNotification(error);
-        }
+        closeNotification(error);
         console.error(error);
       }
     }

--- a/src/modules/builder/components/main/list/ItemsTable.tsx
+++ b/src/modules/builder/components/main/list/ItemsTable.tsx
@@ -15,7 +15,7 @@ import { DiscriminatedItem, ItemType, PackedItem } from '@graasp/sdk';
 import { useParams } from '@tanstack/react-router';
 
 import { NS } from '@/config/constants';
-import { getCatchErrorMessage } from '@/config/notifier';
+import { getErrorMessage } from '@/config/notifier';
 import { hooks, mutations } from '@/config/queryClient';
 import Button from '@/ui/buttons/Button/Button';
 import DraggingWrapper from '@/ui/draggable/DraggingWrapper';

--- a/src/modules/builder/components/main/list/ItemsTable.tsx
+++ b/src/modules/builder/components/main/list/ItemsTable.tsx
@@ -15,6 +15,7 @@ import { DiscriminatedItem, ItemType, PackedItem } from '@graasp/sdk';
 import { useParams } from '@tanstack/react-router';
 
 import { NS } from '@/config/constants';
+import { getCatchErrorMessage } from '@/config/notifier';
 import { hooks, mutations } from '@/config/queryClient';
 import Button from '@/ui/buttons/Button/Button';
 import DraggingWrapper from '@/ui/draggable/DraggingWrapper';
@@ -99,6 +100,7 @@ const ItemsTable = ({
           close();
         })
         .catch((e) => {
+          console.error(e);
           close(e);
         });
       return;
@@ -147,6 +149,7 @@ const ItemsTable = ({
           close();
         })
         .catch((e) => {
+          console.log(e);
           close(e);
         });
     } else if (!itemId || !parentItem) {

--- a/src/modules/builder/components/main/list/ItemsTable.tsx
+++ b/src/modules/builder/components/main/list/ItemsTable.tsx
@@ -15,7 +15,6 @@ import { DiscriminatedItem, ItemType, PackedItem } from '@graasp/sdk';
 import { useParams } from '@tanstack/react-router';
 
 import { NS } from '@/config/constants';
-import { getErrorMessage } from '@/config/notifier';
 import { hooks, mutations } from '@/config/queryClient';
 import Button from '@/ui/buttons/Button/Button';
 import DraggingWrapper from '@/ui/draggable/DraggingWrapper';
@@ -149,7 +148,6 @@ const ItemsTable = ({
           close();
         })
         .catch((e) => {
-          console.log(e);
           close(e);
         });
     } else if (!itemId || !parentItem) {

--- a/src/modules/builder/components/thumbnails/ThumbnailUploader.hook.tsx
+++ b/src/modules/builder/components/thumbnails/ThumbnailUploader.hook.tsx
@@ -97,7 +97,8 @@ export const useThumbnailUploader = ({
       console.error(error);
       setIsUploadingError(true);
       updateHasThumbnail(false);
-      closeNotification(error as Error);
+
+      closeNotification(error);
     } finally {
       setIsThumbnailUploading(false);
       setUploadingProgress(0);

--- a/src/ui/upload/FileDropper/FileDropper.stories.tsx
+++ b/src/ui/upload/FileDropper/FileDropper.stories.tsx
@@ -63,9 +63,10 @@ export const Container = {
   },
 } satisfies Story;
 
+const errorText = 'You cannot upload more than 10 files at a time';
 export const WithError = {
   args: {
-    error: 'You cannot upload more than 10 files at a time',
+    error: <>{errorText}</>,
     hints: 'Max 15GB',
   },
   decorators: [
@@ -73,9 +74,9 @@ export const WithError = {
       return <Box height="400px">{story()}</Box>;
     },
   ],
-  play: ({ canvasElement, args }) => {
+  play: ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    expect(canvas.getByText(args.error!).parentNode).toHaveRole('alert');
+    expect(canvas.getByText(errorText).parentNode).toHaveRole('alert');
     expect(canvas.getByRole('dropzone')).toHaveStyle({
       'background-color': '#ffbaba',
     });

--- a/src/ui/upload/FileDropper/FileDropper.tsx
+++ b/src/ui/upload/FileDropper/FileDropper.tsx
@@ -30,7 +30,7 @@ export type FileDropperProps = {
   /**
    * Error to show
    */
-  error?: string;
+  error?: ReactNode;
   /**
    * Smaller text to show, such as limits
    */


### PR DESCRIPTION
The frontend shows the file-upload errors correctly:

- drop zone (modal, empty folder): shows the error in the dropzone
- drop in between rows: shows a notification

I guess it would be easier to have the same mechanism however we upload the file. So to move to notifications/progress dialog.


https://github.com/user-attachments/assets/27bc025d-99cc-4c72-a62f-46cf83124957


https://github.com/user-attachments/assets/cc2c5d48-d8df-4a8a-b8c4-df9dfaa3c32d


https://github.com/user-attachments/assets/945c1b95-00ef-4490-bdbb-732f62320af8

