### PR TITLE
fix: add the contact information to the maintenance banner

### DIFF
--- a/src/locales/en/builder.json
+++ b/src/locales/en/builder.json
@@ -536,6 +536,7 @@
   "MAINTENANCE": {
     "TITLE": "Maintenance",
     "INTRODUCTION": "A maintenance operation requiring the shutdown of the Graasp platform will be carried out from <b>{{fromDate}}</b> to <b>{{toDate}}</b>.",
-    "DETAILS": "graasp.org will be completely unavailable from <b>{{fromDate}}</b> and will be available again from <b>{{toDate}}</b>."
+    "DETAILS": "graasp.org will be completely unavailable from <b>{{fromDate}}</b> and will be available again from <b>{{toDate}}</b>.",
+    "CONTACT": "This maintenance is affecting your activities on Graasp? We are listening! Contact us at <strong>maintenance@graasp.org</strong>"
   }
 }

--- a/src/locales/en/builder.json
+++ b/src/locales/en/builder.json
@@ -537,6 +537,6 @@
     "TITLE": "Maintenance",
     "INTRODUCTION": "A maintenance operation requiring the shutdown of the Graasp platform will be carried out from <b>{{fromDate}}</b> to <b>{{toDate}}</b>.",
     "DETAILS": "graasp.org will be completely unavailable from <b>{{fromDate}}</b> and will be available again from <b>{{toDate}}</b>.",
-    "CONTACT": "This maintenance is affecting your activities on Graasp? We are listening! Contact us at <strong>maintenance@graasp.org</strong>"
+    "CONTACT": "Will this maintenance affect your activities on Graasp? We are here to listen! Contact us at <strong>maintenance@graasp.org</strong>"
   }
 }

--- a/src/locales/fr/builder.json
+++ b/src/locales/fr/builder.json
@@ -536,6 +536,6 @@
     "TITLE": "Maintenance",
     "INTRODUCTION": "Une opération de maintenance nécessitant l'arrêt de la plateforme Graasp va être effectuée du <b>{{fromDate}}</b> au <b>{{toDate}}</b>.",
     "DETAILS": "graasp.org sera entièrement indisponible à partir du <b>{{fromDate}}</b> et sera à nouveau disponible le <b>{{toDate}}</b>.",
-    "CONTACT": "Cette maintenance affecte vos activités dans Graasp ? Nous sommes à l'écoute ! Contactez nous à <strong>maintenance@graasp.org</strong>"
+    "CONTACT": "Cette maintenance affecte vos activités dans Graasp ? Nous sommes à l'écoute ! Contactez-nous à <strong>maintenance@graasp.org</strong>"
   }
 }

--- a/src/locales/fr/builder.json
+++ b/src/locales/fr/builder.json
@@ -535,6 +535,7 @@
   "MAINTENANCE": {
     "TITLE": "Maintenance",
     "INTRODUCTION": "Une opération de maintenance nécessitant l'arrêt de la plateforme Graasp va être effectuée du <b>{{fromDate}}</b> au <b>{{toDate}}</b>.",
-    "DETAILS": "graasp.org sera entièrement indisponible à partir du <b>{{fromDate}}</b> et sera à nouveau disponible le <b>{{toDate}}</b>."
+    "DETAILS": "graasp.org sera entièrement indisponible à partir du <b>{{fromDate}}</b> et sera à nouveau disponible le <b>{{toDate}}</b>.",
+    "CONTACT": "Cette maintenance affecte vos activités dans Graasp ? Nous sommes à l'écoute ! Contactez nous à <strong>maintenance@graasp.org</strong>"
   }
 }

--- a/src/modules/home/MaintenanceAnnouncement.tsx
+++ b/src/modules/home/MaintenanceAnnouncement.tsx
@@ -12,11 +12,11 @@ import { getNextMaintenanceOptions } from '@/openapi/client/@tanstack/react-quer
 
 import { useLocalStorage } from './useLocalStorage';
 
-function MaintenanceAnnouncement({
+export function MaintenanceAnnouncement({
   suffix,
   showCloseButton = true,
 }: Readonly<{ suffix: string; showCloseButton?: boolean }>) {
-  const { i18n, t } = useTranslation(NS.Builder);
+  const { i18n, t } = useTranslation(NS.Builder, { keyPrefix: 'MAINTENANCE' });
   const { data: maintenance } = useQuery(getNextMaintenanceOptions());
   const { value: isClosed, changeValue: setIsClosed } = useLocalStorage(
     `maintenance-${maintenance?.slug}-closed-${suffix}`,
@@ -45,40 +45,59 @@ function MaintenanceAnnouncement({
           severity="warning"
           sx={{ fontSize: 16 }}
         >
-          <AlertTitle sx={{ fontWeight: 'bold' }}>
-            {t('MAINTENANCE.TITLE')}
-          </AlertTitle>
+          <AlertTitle sx={{ fontWeight: 'bold' }}>{t('TITLE')}</AlertTitle>
           <p>
             <Trans
-              i18n={i18n}
-              ns={NS.Builder}
-              i18nKey="MAINTENANCE.INTRODUCTION"
+              t={t}
+              i18nKey="INTRODUCTION"
               values={{
-                fromDate: formatDate(maintenance.startAt, 'PPP', {
-                  locale: getLocalForDateFns(i18n.language),
-                }),
-                toDate: formatDate(maintenance.endAt, 'PPP', {
-                  locale: getLocalForDateFns(i18n.language),
-                }),
+                fromDate: formatDate(
+                  maintenance.startAt,
+                  // use the long localized date (PPP)
+                  'PPP',
+                  {
+                    locale: getLocalForDateFns(i18n.language),
+                  },
+                ),
+                toDate: formatDate(
+                  maintenance.endAt,
+                  // use the long localized date (PPP)
+                  'PPP',
+                  {
+                    locale: getLocalForDateFns(i18n.language),
+                  },
+                ),
               }}
               components={{ b: <strong /> }}
             />
           </p>
           <p>
             <Trans
-              i18n={i18n}
-              ns={NS.Builder}
-              i18nKey="MAINTENANCE.DETAILS"
+              t={t}
+              i18nKey="DETAILS"
               values={{
-                fromDate: formatDate(maintenance.startAt, 'PPPppp', {
-                  locale: getLocalForDateFns(i18n.language),
-                }),
-                toDate: formatDate(maintenance.endAt, 'PPPppp', {
-                  locale: getLocalForDateFns(i18n.language),
-                }),
+                fromDate: formatDate(
+                  maintenance.startAt,
+                  // use the long localized date (PPP) and short localized time (p) and add the timezone (O)
+                  'PPPp O',
+                  {
+                    locale: getLocalForDateFns(i18n.language),
+                  },
+                ),
+                toDate: formatDate(
+                  maintenance.endAt,
+                  // use the long localized date (PPP) and short localized time (p) and add the timezone (O)
+                  'PPPp O',
+                  {
+                    locale: getLocalForDateFns(i18n.language),
+                  },
+                ),
               }}
               components={{ b: <strong /> }}
             />
+          </p>
+          <p>
+            <Trans t={t} i18nKey="CONTACT" />
           </p>
         </Alert>
       </Collapse>
@@ -87,5 +106,3 @@ function MaintenanceAnnouncement({
 
   return null;
 }
-
-export default MaintenanceAnnouncement;

--- a/src/modules/player/item/MainScreen.tsx
+++ b/src/modules/player/item/MainScreen.tsx
@@ -9,7 +9,7 @@ import { getRouteApi } from '@tanstack/react-router';
 
 import { NS } from '@/config/constants';
 import { hooks, mutations } from '@/config/queryClient';
-import MaintenanceAnnouncement from '@/modules/home/MaintenanceAnnouncement';
+import { MaintenanceAnnouncement } from '@/modules/home/MaintenanceAnnouncement';
 
 import { LayoutContextProvider } from '~player/contexts/LayoutContext';
 import SideContent from '~player/rightPanel/SideContent';

--- a/src/routes/_landing/index.tsx
+++ b/src/routes/_landing/index.tsx
@@ -2,7 +2,7 @@ import { Stack } from '@mui/material';
 
 import { createFileRoute } from '@tanstack/react-router';
 
-import MaintenanceAnnouncement from '@/modules/home/MaintenanceAnnouncement';
+import { MaintenanceAnnouncement } from '@/modules/home/MaintenanceAnnouncement';
 
 import { PlatformCube } from '~landing/Platforms/PlatformCube';
 import { NewsLetter } from '~landing/home/NewsLetter';

--- a/src/routes/_memberOnly/_homeLayout/home.tsx
+++ b/src/routes/_memberOnly/_homeLayout/home.tsx
@@ -2,7 +2,7 @@ import { Divider, Stack, useMediaQuery, useTheme } from '@mui/material';
 
 import { createFileRoute } from '@tanstack/react-router';
 
-import MaintenanceAnnouncement from '@/modules/home/MaintenanceAnnouncement';
+import { MaintenanceAnnouncement } from '@/modules/home/MaintenanceAnnouncement';
 import { BookmarkedItems } from '@/modules/home/bookmarks/BookmarkedItems';
 
 import { FilterItemsContextProvider } from '~builder/components/context/FilterItemsContext';


### PR DESCRIPTION
<img width="1030" alt="Screenshot 2025-05-08 at 16 27 10" src="https://github.com/user-attachments/assets/e8012d3c-452d-4f9a-83d0-b23422897a98" />

I have updated the format of the date to remove the seconds. I don't think we are time critial to the point where we need seconds in the announcement. You can compare the previous format and the proposed format in the image below:
<img width="479" alt="Screenshot 2025-05-08 at 16 23 23" src="https://github.com/user-attachments/assets/b4ab9dab-62d1-40e0-8521-36c60bafff74" />
