### PR TITLE
fix: make login button color white on app header

### DIFF
--- a/src/components/ui/HeaderRightContent.tsx
+++ b/src/components/ui/HeaderRightContent.tsx
@@ -47,5 +47,9 @@ export function HeaderRightContent() {
   }
 
   // in case the user is not authenticated, we show a login button
-  return <ButtonLink to="/auth/login">{t('LOG_IN')}</ButtonLink>;
+  return (
+    <ButtonLink to="/auth/login" sx={{ color: 'white' }}>
+      {t('LOG_IN')}
+    </ButtonLink>
+  );
 }


### PR DESCRIPTION
In this PR I propose to change the login button text color to white to make it more visible when dispalyed on the app header color.

Preview of the change:
<img width="1206" alt="Screenshot 2025-06-16 at 12 22 06" src="https://github.com/user-attachments/assets/4364d3af-b71a-44b4-bd45-ceae205a7e8b" />
<img width="1206" alt="Screenshot 2025-06-16 at 12 21 59" src="https://github.com/user-attachments/assets/c718ba8a-6dd8-472b-a76d-1ff714b15bad" />
