### PR TITLE
fix: upgrade happy-dom to fix issues with query tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "eslint-plugin-react-refresh": "0.4.20",
     "eslint-plugin-storybook": "9.0.12",
     "globals": "15.15.0",
-    "happy-dom": "17.4.7",
+    "happy-dom": "18.0.1",
     "husky": "9.1.7",
     "jose": "5.10.0",
     "nock": "13.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,8 +370,8 @@ importers:
         specifier: 15.15.0
         version: 15.15.0
       happy-dom:
-        specifier: 17.4.7
-        version: 17.4.7
+        specifier: 18.0.1
+        version: 18.0.1
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -413,7 +413,7 @@ importers:
         version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3))
       vitest:
         specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.3)(happy-dom@17.4.7)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.3)(happy-dom@18.0.1)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)
 
 packages:
 
@@ -2511,6 +2511,9 @@ packages:
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
+  '@types/node@20.19.1':
+    resolution: {integrity: sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==}
+
   '@types/node@22.15.3':
     resolution: {integrity: sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==}
 
@@ -2568,6 +2571,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -3704,8 +3710,8 @@ packages:
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
-  enhanced-resolve@5.18.1:
-    resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
+  enhanced-resolve@5.18.2:
+    resolution: {integrity: sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.4.1:
@@ -4353,9 +4359,9 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
 
-  happy-dom@17.4.7:
-    resolution: {integrity: sha512-NZypxadhCiV5NT4A+Y86aQVVKQ05KDmueja3sz008uJfDRwz028wd0aTiJPwo4RQlvlz0fznkEEBBCHVNWc08g==}
-    engines: {node: '>=18.0.0'}
+  happy-dom@18.0.1:
+    resolution: {integrity: sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA==}
+    engines: {node: '>=20.0.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -8951,7 +8957,7 @@ snapshots:
     optionalDependencies:
       '@vitest/browser': 3.2.4(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3))(vitest@3.2.4)
       '@vitest/runner': 3.2.4
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.3)(happy-dom@17.4.7)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.3)(happy-dom@18.0.1)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -9316,6 +9322,10 @@ snapshots:
 
   '@types/ms@0.7.34': {}
 
+  '@types/node@20.19.1':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@22.15.3':
     dependencies:
       undici-types: 6.21.0
@@ -9368,6 +9378,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/whatwg-mimetype@3.0.2': {}
 
   '@types/yauzl@2.10.3':
     dependencies:
@@ -9589,7 +9601,7 @@ snapshots:
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.3)(happy-dom@17.4.7)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.3)(happy-dom@18.0.1)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)
       ws: 8.18.2
     optionalDependencies:
       playwright: 1.52.0
@@ -9664,7 +9676,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.13
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.3)(happy-dom@17.4.7)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.3)(happy-dom@18.0.1)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)
 
   '@vitest/utils@3.0.9':
     dependencies:
@@ -10617,7 +10629,7 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.18.1:
+  enhanced-resolve@5.18.2:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.2
@@ -11530,9 +11542,10 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
-  happy-dom@17.4.7:
+  happy-dom@18.0.1:
     dependencies:
-      webidl-conversions: 7.0.0
+      '@types/node': 20.19.1
+      '@types/whatwg-mimetype': 3.0.2
       whatwg-mimetype: 3.0.0
 
   has-bigints@1.1.0: {}
@@ -14330,7 +14343,7 @@ snapshots:
       terser: 5.43.1
       tsx: 4.20.3
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.3)(happy-dom@17.4.7)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.3)(happy-dom@18.0.1)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -14360,7 +14373,7 @@ snapshots:
       '@types/node': 22.15.3
       '@vitest/browser': 3.2.4(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(terser@5.43.1)(tsx@4.20.3))(vitest@3.2.4)
       '@vitest/ui': 3.1.3(vitest@3.2.4)
-      happy-dom: 17.4.7
+      happy-dom: 18.0.1
       jsdom: 26.0.0
     transitivePeerDependencies:
       - jiti
@@ -14390,7 +14403,8 @@ snapshots:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
-  webidl-conversions@7.0.0: {}
+  webidl-conversions@7.0.0:
+    optional: true
 
   webpack-sources@3.3.3: {}
 
@@ -14406,7 +14420,7 @@ snapshots:
       acorn: 8.15.0
       browserslist: 4.25.0
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.18.1
+      enhanced-resolve: 5.18.2
       es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0

--- a/src/query/utils/util.ts
+++ b/src/query/utils/util.ts
@@ -1,6 +1,3 @@
-export const isServer = () =>
-  !(typeof window !== 'undefined' && window.document);
-
 export const paginate = <U>(
   list: U[],
   pageSize: number,


### PR DESCRIPTION
We have still some failures (flacky) with the vitest query suite. 

In this PR I upgrade `happy-dom` to try to make them disappear. It is possible that react 19 which we are using is more strict about DOM apis... let's see.

It that does not resolve it, we could switch to `jsdom` which is more feature complete be also a bit heavier.
Otherwise an option is to focus our work on moving more code to the generation and minimise and remove the query test suite.