### PR TITLE
fix: notify users when the description is too long

### DIFF
--- a/cypress/e2e/builder/item/create/createFolder.cy.ts
+++ b/cypress/e2e/builder/item/create/createFolder.cy.ts
@@ -1,5 +1,6 @@
 import { PackedFolderItemFactory } from '@graasp/sdk';
 
+import { MAX_DESCRIPTION_LENGTH } from '../../../../../src/config/constants';
 import {
   FOLDER_FORM_DESCRIPTION_ID,
   ITEM_FORM_CONFIRM_BUTTON_ID,
@@ -44,8 +45,6 @@ describe('Create Folder', () => {
     cy.visit(HOME_PATH);
     createFolder({ name: ' ' }, { confirm: false });
 
-    // button is not disabled at beginning
-    // cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).click();
     cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).should('be.disabled');
   });
 
@@ -54,14 +53,14 @@ describe('Create Folder', () => {
     cy.setUpApi();
     cy.visit(HOME_PATH);
     createFolder(
-      { name: 'correct', description: 'x'.repeat(5001) },
+      { name: 'correct', description: 'x'.repeat(MAX_DESCRIPTION_LENGTH + 10) },
       { confirm: false },
     );
 
-    // button is not disabled at beginning
-    // cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).click();
     cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).should('be.disabled');
-    cy.get(`#${FOLDER_FORM_DESCRIPTION_ID}-error`).should('be.visible');
+    cy.get(`#${FOLDER_FORM_DESCRIPTION_ID}-error`)
+      .scrollIntoView()
+      .should('be.visible');
   });
 
   it('description placement should not exist for folder', () => {

--- a/cypress/e2e/builder/item/create/createFolder.cy.ts
+++ b/cypress/e2e/builder/item/create/createFolder.cy.ts
@@ -1,6 +1,7 @@
 import { PackedFolderItemFactory } from '@graasp/sdk';
 
 import {
+  FOLDER_FORM_DESCRIPTION_ID,
   ITEM_FORM_CONFIRM_BUTTON_ID,
   ITEM_SETTING_DESCRIPTION_PLACEMENT_SELECT_ID,
 } from '../../../../../src/config/selectors';
@@ -44,8 +45,23 @@ describe('Create Folder', () => {
     createFolder({ name: ' ' }, { confirm: false });
 
     // button is not disabled at beginning
-    cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).click();
+    // cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).click();
     cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).should('be.disabled');
+  });
+
+  it('cannot create folder with description too long', () => {
+    // create
+    cy.setUpApi();
+    cy.visit(HOME_PATH);
+    createFolder(
+      { name: 'correct', description: 'x'.repeat(5001) },
+      { confirm: false },
+    );
+
+    // button is not disabled at beginning
+    // cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).click();
+    cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).should('be.disabled');
+    cy.get(`#${FOLDER_FORM_DESCRIPTION_ID}-error`).should('be.visible');
   });
 
   it('description placement should not exist for folder', () => {

--- a/cypress/e2e/builder/item/edit/editFolder.cy.ts
+++ b/cypress/e2e/builder/item/edit/editFolder.cy.ts
@@ -19,7 +19,7 @@ const EDITED_FIELDS = {
 };
 
 describe('Edit Folder', () => {
-  it('confirm with empty name', () => {
+  it('cannot make name empty', () => {
     const item = PackedFolderItemFactory();
     cy.setUpApi({ items: [item] });
     cy.visit(HOME_PATH);
@@ -39,6 +39,29 @@ describe('Edit Folder', () => {
 
     // check that the button can not be clicked
     cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).should('be.disabled');
+  });
+
+  it('cannot save description too long', () => {
+    const item = PackedFolderItemFactory();
+    cy.setUpApi({ items: [item] });
+    cy.visit(HOME_PATH);
+
+    // click edit button
+    const itemId = item.id;
+    cy.get(buildItemsGridMoreButtonSelector(itemId)).click();
+    cy.get(`.${EDIT_ITEM_BUTTON_CLASS}`).click();
+
+    cy.fillFolderModal(
+      {
+        // put an empty name for the folder
+        description: 'x'.repeat(5001),
+      },
+      { confirm: false },
+    );
+
+    // check that the button can not be clicked
+    cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).should('be.disabled');
+    cy.get(`#${FOLDER_FORM_DESCRIPTION_ID}-error`).should('be.visible');
   });
 
   it('edit folder on Home', () => {

--- a/cypress/e2e/builder/item/edit/editFolder.cy.ts
+++ b/cypress/e2e/builder/item/edit/editFolder.cy.ts
@@ -1,5 +1,6 @@
 import { PackedFolderItemFactory } from '@graasp/sdk';
 
+import { MAX_DESCRIPTION_LENGTH } from '../../../../../src/config/constants';
 import {
   EDIT_ITEM_BUTTON_CLASS,
   EDIT_ITEM_MODAL_CANCEL_BUTTON_ID,
@@ -19,7 +20,7 @@ const EDITED_FIELDS = {
 };
 
 describe('Edit Folder', () => {
-  it('cannot make name empty', () => {
+  it('cannot save item with empty name', () => {
     const item = PackedFolderItemFactory();
     cy.setUpApi({ items: [item] });
     cy.visit(HOME_PATH);
@@ -54,7 +55,7 @@ describe('Edit Folder', () => {
     cy.fillFolderModal(
       {
         // put an empty name for the folder
-        description: 'x'.repeat(5001),
+        description: 'x'.repeat(MAX_DESCRIPTION_LENGTH + 10),
       },
       { confirm: false },
     );

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -40,3 +40,4 @@ export const DEFAULT_LINK_SHOW_BUTTON = true;
 export const DEFAULT_LINK_SHOW_IFRAME = false;
 
 export const ITEM_NAME_MAX_LENGTH = 15;
+export const MAX_DESCRIPTION_LENGTH = 5000;

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -156,5 +156,6 @@
   "CANNOT_ENROLL_FROZEN_ITEM_LOGIN_SCHEMA": "Cannot enroll in the targeted item because the subscription has been frozen by its owner",
   "NOT_MEMBER_OR_GUEST": "Your account is not registered as member or pseudonimized user",
   "INVALID_ITEM_NAME_PATTERN_ERROR": "The item's name is not valid. It should start and end with an alphabetical character.",
-  "INVALID_ITEM_NAME_MAX_LENGTH_ERROR": "The item's name is too long."
+  "INVALID_ITEM_NAME_MAX_LENGTH_ERROR": "The item's name is too long.",
+  "INVALID_ITEM_DESCRIPTION_MAX_LENGTH_ERROR": "Your description is too long, keep descriptions short. Use a text element inside your page for longer descriptions."
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -157,5 +157,5 @@
   "NOT_MEMBER_OR_GUEST": "Your account is not registered as member or pseudonimized user",
   "INVALID_ITEM_NAME_PATTERN_ERROR": "The item's name is not valid. It should start and end with an alphabetical character.",
   "INVALID_ITEM_NAME_MAX_LENGTH_ERROR": "The item's name is too long.",
-  "INVALID_ITEM_DESCRIPTION_MAX_LENGTH_ERROR": "Your description is too long, keep descriptions short. Use a text element inside your page for longer descriptions."
+  "INVALID_ITEM_DESCRIPTION_MAX_LENGTH_ERROR": "Your description is too long, descriptions should be short. If you want longer descriptions, use a text element inside your page."
 }

--- a/src/modules/builder/components/item/edit/EditModal.tsx
+++ b/src/modules/builder/components/item/edit/EditModal.tsx
@@ -81,7 +81,7 @@ export function EditModal({
       onClose={onClose}
       id={EDIT_MODAL_ID}
       open={open}
-      maxWidth="sm"
+      maxWidth="md"
       fullWidth
     >
       <DialogTitle id={item?.id}>

--- a/src/modules/builder/components/item/form/description/DescriptionAndPlacementForm.tsx
+++ b/src/modules/builder/components/item/form/description/DescriptionAndPlacementForm.tsx
@@ -1,5 +1,4 @@
 import type { JSX } from 'react';
-import { Controller, useFormContext } from 'react-hook-form';
 
 import { Stack } from '@mui/material';
 
@@ -13,23 +12,9 @@ type DescriptionAndPlacementFormProps = {
 export function DescriptionAndPlacementForm({
   id,
 }: Readonly<DescriptionAndPlacementFormProps>): JSX.Element {
-  const { control } = useFormContext<{
-    description: string;
-  }>();
   return (
     <Stack spacing={2}>
-      <Controller
-        name="description"
-        control={control}
-        render={({ field }) => (
-          <DescriptionForm
-            id={id}
-            // ref={descriptionRegister.ref}
-            value={field.value}
-            onChange={(v) => field.onChange(v)}
-          />
-        )}
-      />
+      <DescriptionForm id={id} />
       <DescriptionPlacementForm />
     </Stack>
   );

--- a/src/modules/builder/components/item/form/description/DescriptionForm.tsx
+++ b/src/modules/builder/components/item/form/description/DescriptionForm.tsx
@@ -4,14 +4,12 @@ import { useTranslation } from 'react-i18next';
 
 import { Alert, Box, FormLabel, Typography } from '@mui/material';
 
-import { NS } from '@/config/constants';
+import { MAX_DESCRIPTION_LENGTH, NS } from '@/config/constants';
 import TextEditor from '@/ui/TextEditor/TextEditor';
 
 export type DescriptionFormProps = {
   id?: string;
 };
-
-export const MAX_DESCRIPTION_LENGTH = 5000;
 
 export function DescriptionForm({
   id,

--- a/src/modules/builder/components/item/form/description/DescriptionForm.tsx
+++ b/src/modules/builder/components/item/form/description/DescriptionForm.tsx
@@ -1,36 +1,59 @@
 import type { JSX } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
-import { Box, FormLabel, Typography } from '@mui/material';
+import { Alert, Box, FormLabel, Typography } from '@mui/material';
 
 import { NS } from '@/config/constants';
 import TextEditor from '@/ui/TextEditor/TextEditor';
 
 export type DescriptionFormProps = {
   id?: string;
-  value?: string;
-  onChange: (v: string) => void;
 };
+
+export const MAX_DESCRIPTION_LENGTH = 5000;
 
 export function DescriptionForm({
   id,
-  value = '',
-  onChange,
 }: Readonly<DescriptionFormProps>): JSX.Element {
-  const { t: translateBuilder } = useTranslation(NS.Builder, {
+  const { control } = useFormContext<{
+    description: string;
+  }>();
+  const { t: translateMessages } = useTranslation(NS.Messages);
+  const { t } = useTranslation(NS.Builder, {
     keyPrefix: 'DESCRIPTION',
   });
-
   return (
     <Box>
       <FormLabel>
-        <Typography variant="caption">{translateBuilder('LABEL')}</Typography>
+        <Typography variant="caption">{t('LABEL')}</Typography>
       </FormLabel>
-      <TextEditor
-        id={id}
-        value={value}
-        onChange={onChange}
-        placeholderText={translateBuilder('PLACEHOLDER')}
+      <Controller
+        name="description"
+        control={control}
+        rules={{
+          maxLength: {
+            value: MAX_DESCRIPTION_LENGTH,
+            message: translateMessages(
+              'INVALID_ITEM_DESCRIPTION_MAX_LENGTH_ERROR',
+            ),
+          },
+        }}
+        render={({ field, formState: { errors } }) => (
+          <>
+            {errors.description?.message && (
+              <Alert id={`${id}-error`} severity="error">
+                {errors.description.message}
+              </Alert>
+            )}
+            <TextEditor
+              id={id}
+              value={field.value}
+              onChange={(v) => field.onChange(v)}
+              placeholderText={t('PLACEHOLDER')}
+            />
+          </>
+        )}
       />
     </Box>
   );

--- a/src/modules/builder/components/item/form/folder/FolderCreateForm.tsx
+++ b/src/modules/builder/components/item/form/folder/FolderCreateForm.tsx
@@ -52,15 +52,12 @@ export function FolderCreateForm({
   const [clickCounter, setClickCounter] = useState(0);
   const { t: translateBuilder } = useTranslation(NS.Builder);
   const { t: translateCommon } = useTranslation(NS.Common);
-  const methods = useForm<Inputs>();
+  const methods = useForm<Inputs>({ mode: 'onChange' });
   const {
-    setValue,
-    watch,
     handleSubmit,
-    formState: { isValid, isSubmitted },
+    formState: { isValid },
   } = methods;
 
-  const description = watch('description');
   const [thumbnail, setThumbnail] = useState<Blob>();
 
   const { mutateAsync: createItem } = mutations.usePostItem();
@@ -123,13 +120,7 @@ export function FolderCreateForm({
             />
             <ItemNameField required />
           </Stack>
-          <DescriptionForm
-            id={FOLDER_FORM_DESCRIPTION_ID}
-            value={description}
-            onChange={(newValue) => {
-              setValue('description', newValue);
-            }}
-          />
+          <DescriptionForm id={FOLDER_FORM_DESCRIPTION_ID} />
         </DialogContent>
         <DialogActions>
           {clickCounter > 3 && (
@@ -141,7 +132,7 @@ export function FolderCreateForm({
           <Button
             id={ITEM_FORM_CONFIRM_BUTTON_ID}
             type="submit"
-            disabled={isSubmitted && !isValid}
+            disabled={!isValid}
           >
             {translateCommon('SAVE.BUTTON_TEXT')}
           </Button>

--- a/src/modules/builder/components/item/form/folder/FolderEditForm.tsx
+++ b/src/modules/builder/components/item/form/folder/FolderEditForm.tsx
@@ -40,14 +40,12 @@ export function FolderEditForm({
       name: item.name,
       description: item.description ?? '',
     },
+    mode: 'onChange',
   });
   const {
-    setValue,
-    watch,
     handleSubmit,
     formState: { isValid },
   } = methods;
-  const description = watch('description');
 
   const { mutateAsync: editItem } = mutations.useEditItem();
 
@@ -69,13 +67,7 @@ export function FolderEditForm({
       <Box component="form" onSubmit={handleSubmit(onSubmit)}>
         <DialogContent>
           <ItemNameField required />
-          <DescriptionForm
-            id={FOLDER_FORM_DESCRIPTION_ID}
-            value={description ?? item?.description}
-            onChange={(newValue) => {
-              setValue('description', newValue);
-            }}
-          />
+          <DescriptionForm id={FOLDER_FORM_DESCRIPTION_ID} />
         </DialogContent>
         <DialogActions>
           <CancelButton


### PR DESCRIPTION
In this PR I fix #1049 

Currently users can enter a description that is longer than the allowed length (5000 chars in the backend).

I fix this problem by:
- adding an error message when the description is too long
- disabling the submit button so users can't save a description that is too long
- make `create` and `edit` folder forms validate the inputs `onChange` to increase the feedback to the user (previously they would only validate `onSubmit`

While working on this I noticed that the validation mode for the create and edit modals for the folder was set to `onSubmit`. I do not know if there was a reason behind it. @pyphilia do you know ?

Also I changed the `DescriptionForm` component to use `<Controller />` from react-hook-form to make validation more straight forward.

I also changed the size of the edit dialog to match the one of the create (`maxWidth: md`).

Bellow is a demo of the changes:

https://github.com/user-attachments/assets/b314f331-cb10-497d-864e-3c0c0f1c0c4b

