### PR TITLE
fix(page): timeout connection attempts if disconnections are repeated

### DIFF
--- a/src/components/page/Editor.tsx
+++ b/src/components/page/Editor.tsx
@@ -115,6 +115,7 @@ export function Editor({ item, currentAccount }: Readonly<Props>) {
                           // className="editor-input"
                           // necessary for dnd, for shifting text and show drag icon correctly
                           className={'content-editable-root'}
+                          style={{ fontSize: DEFAULT_FONT_SIZE }}
                           aria-placeholder={'Enter some text...'}
                           placeholder={
                             <div className="editor-placeholder">

--- a/src/components/page/Editor.tsx
+++ b/src/components/page/Editor.tsx
@@ -43,7 +43,7 @@ type Props = {
 
 export function Editor({ item, currentAccount }: Readonly<Props>) {
   const { t } = useTranslation(NS.PageEditor);
-  const { providerFactory, activeUsers, connected, hasTimeout } = useYjs({
+  const { providerFactory, activeUsers, connected, hasTimedOut } = useYjs({
     edit: true,
   });
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -68,7 +68,7 @@ export function Editor({ item, currentAccount }: Readonly<Props>) {
   return (
     <div ref={containerRef}>
       <StatusToolbar users={activeUsers} isConnected={connected} />
-      {hasTimeout && (
+      {hasTimedOut && (
         <Alert
           severity="error"
           action={
@@ -85,8 +85,8 @@ export function Editor({ item, currentAccount }: Readonly<Props>) {
           {t('DISCONNECTED_TEXT')}
         </Alert>
       )}
-      {/* disable on timeout to prevent further connection attempts */}
-      {!hasTimeout && (
+      {/* unmount component on timeout to prevent further connection attempts */}
+      {!hasTimedOut && (
         <>
           <LexicalComposer initialConfig={initialConfig}>
             <div

--- a/src/components/page/Editor.tsx
+++ b/src/components/page/Editor.tsx
@@ -67,7 +67,8 @@ export function Editor({ item, currentAccount }: Readonly<Props>) {
 
   return (
     <div ref={containerRef}>
-      {!connected && (
+      <StatusToolbar users={activeUsers} isConnected={connected} />
+      {hasTimeout && (
         <Alert
           severity="error"
           action={
@@ -84,54 +85,57 @@ export function Editor({ item, currentAccount }: Readonly<Props>) {
           {t('DISCONNECTED_TEXT')}
         </Alert>
       )}
-      <StatusToolbar users={activeUsers} isConnected={connected} />
-      <LexicalComposer initialConfig={initialConfig}>
-        <div style={{ width: '100%', height: '100vh', background: 'white' }}>
-          <ToolbarPlugin />
-          <div className="editor-inner">
-            {/* With CollaborationPlugin - we MUST NOT use @lexical/react/LexicalHistoryPlugin */}
-            {/* disable collaboration on timeout to prevent further connection attempts */}
-            {!hasTimeout && (
-              <CollaborationPlugin
-                id={item.id}
-                providerFactory={providerFactory}
-                // Unless you have a way to avoid race condition between 2+ users trying to do bootstrap simultaneously
-                // you should never try to bootstrap on client. It's better to perform bootstrap within Yjs server.
-                shouldBootstrap={false}
-                username={currentAccount.name}
-                cursorColor={stringToColor(currentAccount.id)}
-                cursorsContainerRef={containerRef}
-              />
-            )}
-            <RichTextPlugin
-              contentEditable={
-                // necessary for dnd, or at least for allowing updates
-                <div className="editor-scroller">
-                  <div className="editor" ref={onRef}>
-                    <ContentEditable
-                      // className="editor-input"
-                      // necessary for dnd, for shifting text and show drag icon correctly
-                      className={'content-editable-root'}
-                      style={{ fontSize: DEFAULT_FONT_SIZE }}
-                      aria-placeholder={'Enter some text...'}
-                      placeholder={
-                        <div className="editor-placeholder">
-                          Enter some text...
-                        </div>
-                      }
-                    />
-                  </div>
-                </div>
-              }
-              ErrorBoundary={LexicalErrorBoundary}
-            />
-            <AutoFocusPlugin />
-            {floatingAnchorElem && (
-              <DraggableBlockPlugin anchorElem={floatingAnchorElem} />
-            )}
-          </div>
-        </div>
-      </LexicalComposer>
+      {/* disable on timeout to prevent further connection attempts */}
+      {!hasTimeout && (
+        <>
+          <LexicalComposer initialConfig={initialConfig}>
+            <div
+              style={{ width: '100%', height: '100vh', background: 'white' }}
+            >
+              <ToolbarPlugin />
+              <div className="editor-inner">
+                {/* With CollaborationPlugin - we MUST NOT use @lexical/react/LexicalHistoryPlugin */}
+
+                <CollaborationPlugin
+                  id={item.id}
+                  providerFactory={providerFactory}
+                  // Unless you have a way to avoid race condition between 2+ users trying to do bootstrap simultaneously
+                  // you should never try to bootstrap on client. It's better to perform bootstrap within Yjs server.
+                  shouldBootstrap={false}
+                  username={currentAccount.name}
+                  cursorColor={stringToColor(currentAccount.id)}
+                  cursorsContainerRef={containerRef}
+                />
+                <RichTextPlugin
+                  contentEditable={
+                    // necessary for dnd, or at least for allowing updates
+                    <div className="editor-scroller">
+                      <div className="editor" ref={onRef}>
+                        <ContentEditable
+                          // className="editor-input"
+                          // necessary for dnd, for shifting text and show drag icon correctly
+                          className={'content-editable-root'}
+                          aria-placeholder={'Enter some text...'}
+                          placeholder={
+                            <div className="editor-placeholder">
+                              Enter some text...
+                            </div>
+                          }
+                        />
+                      </div>
+                    </div>
+                  }
+                  ErrorBoundary={LexicalErrorBoundary}
+                />
+                <AutoFocusPlugin />
+                {floatingAnchorElem && (
+                  <DraggableBlockPlugin anchorElem={floatingAnchorElem} />
+                )}
+              </div>
+            </div>
+          </LexicalComposer>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/page/Editor.tsx
+++ b/src/components/page/Editor.tsx
@@ -1,4 +1,7 @@
 import { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Alert, Button } from '@mui/material';
 
 import { PageItemType } from '@graasp/sdk';
 
@@ -15,6 +18,7 @@ import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { ParagraphNode, TextNode } from 'lexical';
 
 import { AuthenticatedMember } from '@/AuthContext';
+import { NS } from '@/config/constants';
 import { stringToColor } from '@/ui/Avatar/stringToColor';
 
 import { StatusToolbar } from './StatusToolbar';
@@ -38,7 +42,8 @@ type Props = {
 };
 
 export function Editor({ item, currentAccount }: Readonly<Props>) {
-  const { providerFactory, activeUsers, connected } = useYjs({
+  const { t } = useTranslation(NS.PageEditor);
+  const { providerFactory, activeUsers, connected, hasTimeout } = useYjs({
     edit: true,
   });
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -62,22 +67,42 @@ export function Editor({ item, currentAccount }: Readonly<Props>) {
 
   return (
     <div ref={containerRef}>
+      {!connected && (
+        <Alert
+          severity="error"
+          action={
+            <Button
+              size="small"
+              onClick={() => {
+                window.location.reload();
+              }}
+            >
+              {t('RELOAD_BUTTON')}
+            </Button>
+          }
+        >
+          {t('DISCONNECTED_TEXT')}
+        </Alert>
+      )}
       <StatusToolbar users={activeUsers} isConnected={connected} />
       <LexicalComposer initialConfig={initialConfig}>
         <div style={{ width: '100%', height: '100vh', background: 'white' }}>
           <ToolbarPlugin />
           <div className="editor-inner">
             {/* With CollaborationPlugin - we MUST NOT use @lexical/react/LexicalHistoryPlugin */}
-            <CollaborationPlugin
-              id={item.id}
-              providerFactory={providerFactory}
-              // Unless you have a way to avoid race condition between 2+ users trying to do bootstrap simultaneously
-              // you should never try to bootstrap on client. It's better to perform bootstrap within Yjs server.
-              shouldBootstrap={false}
-              username={currentAccount.name}
-              cursorColor={stringToColor(currentAccount.id)}
-              cursorsContainerRef={containerRef}
-            />
+            {/* disable collaboration on timeout to prevent further connection attempts */}
+            {!hasTimeout && (
+              <CollaborationPlugin
+                id={item.id}
+                providerFactory={providerFactory}
+                // Unless you have a way to avoid race condition between 2+ users trying to do bootstrap simultaneously
+                // you should never try to bootstrap on client. It's better to perform bootstrap within Yjs server.
+                shouldBootstrap={false}
+                username={currentAccount.name}
+                cursorColor={stringToColor(currentAccount.id)}
+                cursorsContainerRef={containerRef}
+              />
+            )}
             <RichTextPlugin
               contentEditable={
                 // necessary for dnd, or at least for allowing updates

--- a/src/components/page/StatusToolbar.tsx
+++ b/src/components/page/StatusToolbar.tsx
@@ -1,6 +1,10 @@
-import { Avatar, AvatarGroup, Stack } from '@mui/material';
-
-import { RefreshCwOffIcon } from 'lucide-react';
+import {
+  Avatar,
+  AvatarGroup,
+  CircularProgress,
+  Skeleton,
+  Stack,
+} from '@mui/material';
 
 export function StatusToolbar({
   users,
@@ -9,9 +13,34 @@ export function StatusToolbar({
   users: { name: string }[];
   isConnected: boolean;
 }) {
+  if (!isConnected) {
+    return (
+      <Stack
+        justifyContent="space-between"
+        alignContent="center"
+        direction="row"
+      >
+        <Stack>
+          <CircularProgress size={30} />
+        </Stack>
+        <AvatarGroup sx={{ gap: 1 }}>
+          <Skeleton>
+            <Avatar />
+          </Skeleton>
+          <Skeleton>
+            <Avatar />
+          </Skeleton>
+          <Skeleton>
+            <Avatar />
+          </Skeleton>
+        </AvatarGroup>
+      </Stack>
+    );
+  }
+
   return (
     <Stack justifyContent="space-between" alignContent="center" direction="row">
-      <Stack>{!isConnected && <RefreshCwOffIcon />}</Stack>
+      <Stack>{!isConnected && <CircularProgress size={30} />}</Stack>
       <AvatarGroup>
         {users.map((user) => (
           <Avatar>{user.name[0].toUpperCase()}</Avatar>

--- a/src/components/page/useYjs.ts
+++ b/src/components/page/useYjs.ts
@@ -10,6 +10,7 @@ import { Doc } from 'yjs';
 
 import { WS_HOST } from '@/config/env';
 
+/** Compare consecutive disconnection times  */
 const DISCONNECTION_ATTEMPT_RANGE = 5;
 
 export const useYjs = ({ edit }: { edit: boolean }) => {
@@ -64,7 +65,6 @@ export const useYjs = ({ edit }: { edit: boolean }) => {
             ('connected' in event && event.connected === true),
         );
 
-        // reset connection attempt
         if (event.status === 'disconnected') {
           // keep track of 10 last deconnection dates
           setDisconnectedTimestamps((arr) =>
@@ -86,7 +86,10 @@ export const useYjs = ({ edit }: { edit: boolean }) => {
   // eg. connection attemps happens very quickly
   const [hasTimeout, setHasTimeout] = useState(false);
   useEffect(() => {
-    if (disconnectedTimestamps.length > DISCONNECTION_ATTEMPT_RANGE) {
+    if (
+      !hasTimeout &&
+      disconnectedTimestamps.length > DISCONNECTION_ATTEMPT_RANGE
+    ) {
       const lastDisconnections = disconnectedTimestamps.slice(
         -DISCONNECTION_ATTEMPT_RANGE,
       );
@@ -102,7 +105,7 @@ export const useYjs = ({ edit }: { edit: boolean }) => {
         setHasTimeout(true);
       }
     }
-  }, [disconnectedTimestamps]);
+  }, [disconnectedTimestamps, hasTimeout]);
 
   return {
     providerFactory,

--- a/src/components/page/useYjs.ts
+++ b/src/components/page/useYjs.ts
@@ -84,10 +84,10 @@ export const useYjs = ({ edit }: { edit: boolean }) => {
 
   // fallback if connection is going crazy
   // eg. connection attemps happens very quickly
-  const [hasTimeout, setHasTimeout] = useState(false);
+  const [hasTimedOut, setHasTimeout] = useState(false);
   useEffect(() => {
     if (
-      !hasTimeout &&
+      !hasTimedOut &&
       disconnectedTimestamps.length > DISCONNECTION_ATTEMPT_RANGE
     ) {
       const lastDisconnections = disconnectedTimestamps.slice(
@@ -105,13 +105,13 @@ export const useYjs = ({ edit }: { edit: boolean }) => {
         setHasTimeout(true);
       }
     }
-  }, [disconnectedTimestamps, hasTimeout]);
+  }, [disconnectedTimestamps, hasTimedOut]);
 
   return {
     providerFactory,
     activeUsers,
     connected,
-    hasTimeout,
+    hasTimedOut,
   };
 };
 

--- a/src/locales/en/pageEditor.json
+++ b/src/locales/en/pageEditor.json
@@ -10,5 +10,7 @@
       "INCREASE": "Increase font size",
       "DECREASE": "Decrease font size"
     }
-  }
+  },
+  "DISCONNECTED_TEXT": "You have been disconnected.",
+  "RELOAD_BUTTON": "Reload"
 }


### PR DESCRIPTION
In case the server is throwing an error and closing the connection, the collaboration plugin will retry infinitely to connect (it's the server that failed).
If the error repeats, we can end up in a infinite loop where the websocket gets connected and disconnected repeatedly.

The current timeout implemetation is based on how many times disconnection happens in a short period of time. If we get disconnected 5 times in less than 2 seconds, the interface will show an error and hide the document.

I personally it is a bit shaky as a solution, but since we don't really have access to the websocket provider implementation, I don't really control the retrial mechanism. For now it is okay, let's see how it plays in the sandbox. If later we need more control on the awareness (for example) it will make sense to fork the plugin.

Another solution would be to play with awareness in some ways, ie. store the error state in here, and avoid closing the connection on error (which is the main reason why the client retries). But as mentioned, it would require to fork the plugin.

Let me know what you think.