### PR TITLE
feat: add copy in item page menu

### DIFF
--- a/cypress/e2e/builder/item/copy/copy.cy.ts
+++ b/cypress/e2e/builder/item/copy/copy.cy.ts
@@ -1,12 +1,23 @@
-import { PackedFileItemFactory, PackedFolderItemFactory } from '@graasp/sdk';
+import {
+  MemberFactory,
+  PackedFileItemFactory,
+  PackedFolderItemFactory,
+} from '@graasp/sdk';
+
+import { StatusCodes } from 'http-status-codes';
 
 import {
   COPY_MANY_ITEMS_BUTTON_SELECTOR,
   ITEM_MENU_COPY_BUTTON_CLASS,
+  TREE_MODAL_CONFIRM_BUTTON_ID,
   buildDataCyWrapper,
   buildItemCard,
   buildItemMenuDataCy,
 } from '../../../../../src/config/selectors';
+import {
+  fillPasswordSignInLayout,
+  submitPasswordSignIn,
+} from '../../../auth/util';
 import { HOME_PATH, buildItemPath } from '../../utils';
 
 const copyItems = ({
@@ -200,7 +211,7 @@ describe('Copy Item', () => {
     });
   });
 
-  it('open copy modal for copyOpen=true', () => {
+  it('open copy modal for copyOpen=true and logged in', () => {
     const parentItem = PackedFolderItemFactory();
     const folders = [PackedFolderItemFactory({ parentItem })];
     const toItem = PackedFolderItemFactory();
@@ -216,5 +227,50 @@ describe('Copy Item', () => {
       expect(body.parentId).to.eq(toItem.id);
       expect(url).to.contain(parentItem.id);
     });
+  });
+
+  it('Show copy modal warning for copyOpen=true and logged out, logging in should show copy modal', () => {
+    const parentItem = PackedFolderItemFactory();
+    const folders = [PackedFolderItemFactory({ parentItem })];
+    const toItem = PackedFolderItemFactory();
+    cy.setUpApi({
+      currentMember: null,
+      items: [...folders, parentItem, toItem],
+    });
+
+    // go to item with modal open
+    cy.visit(buildItemPath(parentItem.id) + '?copyOpen=true');
+
+    // should show warning
+    cy.get('[role="dialog"]', { timeout: 10000 }).should('be.visible');
+
+    // go to login
+    cy.get('[role="dialog"] [aria-label="Login"]').click();
+    cy.url().should('contain', '/login');
+
+    cy.intercept(
+      {
+        pathname: '/login-password',
+      },
+      ({ reply }) => {
+        reply({ statusCode: StatusCodes.NO_CONTENT });
+      },
+    ).as('signInWithPassword');
+
+    // manually set current member
+    cy.setUpApi({
+      items: [...folders, parentItem, toItem],
+    });
+
+    // fake sign in
+    fillPasswordSignInLayout({
+      ...MemberFactory(),
+      password: 'some password',
+    });
+    submitPasswordSignIn();
+    cy.wait('@signInWithPassword');
+
+    // should show copy modal
+    cy.get(`#${TREE_MODAL_CONFIRM_BUTTON_ID}`).should('be.visible');
   });
 });

--- a/cypress/e2e/builder/item/copy/copy.cy.ts
+++ b/cypress/e2e/builder/item/copy/copy.cy.ts
@@ -199,4 +199,22 @@ describe('Copy Item', () => {
       expect(url).to.contain(parentItem.id);
     });
   });
+
+  it('open copy modal for copyOpen=true', () => {
+    const parentItem = PackedFolderItemFactory();
+    const folders = [PackedFolderItemFactory({ parentItem })];
+    const toItem = PackedFolderItemFactory();
+    cy.setUpApi({
+      items: [...folders, parentItem, toItem],
+    });
+
+    // go to item with modal open
+    cy.visit(buildItemPath(parentItem.id) + '?copyOpen=true');
+    cy.handleTreeMenu(toItem.path);
+
+    cy.wait('@copyItems').then(({ request: { url, body } }) => {
+      expect(body.parentId).to.eq(toItem.id);
+      expect(url).to.contain(parentItem.id);
+    });
+  });
 });

--- a/cypress/e2e/builder/item/copy/copy.cy.ts
+++ b/cypress/e2e/builder/item/copy/copy.cy.ts
@@ -175,4 +175,28 @@ describe('Copy Item', () => {
       });
     });
   });
+
+  it('copy item from item page', () => {
+    const parentItem = PackedFolderItemFactory();
+    const folders = [
+      PackedFolderItemFactory({ parentItem }),
+      PackedFolderItemFactory({ parentItem }),
+      PackedFolderItemFactory({ parentItem }),
+    ];
+    const toItem = PackedFolderItemFactory();
+    cy.setUpApi({
+      items: [...folders, parentItem, toItem],
+    });
+
+    // go to item
+    cy.visit(buildItemPath(parentItem.id));
+    cy.get(`[aria-label="More"]`).click();
+    cy.get(`[role="menuitem"][aria-label="Copy"]`).click();
+    cy.handleTreeMenu(toItem.path);
+
+    cy.wait('@copyItems').then(({ request: { url, body } }) => {
+      expect(body.parentId).to.eq(toItem.id);
+      expect(url).to.contain(parentItem.id);
+    });
+  });
 });

--- a/src/locales/en/builder.json
+++ b/src/locales/en/builder.json
@@ -28,6 +28,11 @@
   "COPY_ITEM_MODAL_TITLE_zero": "Where do you want to copy {{name}}?",
   "COPY_ITEM_MODAL_TITLE_one": "Where do you want to copy {{name}} and one other?",
   "COPY_ITEM_MODAL_TITLE_other": "Where do you want to copy {{name}} and {{count}} others?",
+  "COPY_WARNING_MODAL": {
+    "TITLE": "Copy {{name}}",
+    "DESCRIPTION": "You need to be logged in to copy this item.",
+    "LOGIN": "Login"
+  },
   "ITEM_TEMPLATE_SELECTION_MODAL_TITLE": "Which item do you want to use as the template for the groups?",
   "ITEM_TEMPLATE_SELECTION_BUTTON": "Use {{name}} as template",
   "CREATE_ITEM_ADD_BUTTON": "Add",

--- a/src/locales/fr/builder.json
+++ b/src/locales/fr/builder.json
@@ -28,6 +28,11 @@
   "COPY_ITEM_MODAL_TITLE_zero": "Où voulez-vous copier {{name}}?",
   "COPY_ITEM_MODAL_TITLE_one": "Où voulez-vous copier {{name}} et un autre?",
   "COPY_ITEM_MODAL_TITLE_other": "Où voulez-vous copier {{name}} et {{count}} autres?",
+  "COPY_WARNING_MODAL": {
+    "TITLE": "Copier {{name}}",
+    "DESCRIPTION": "Vous devez être connecté pour copier cet élément.",
+    "LOGIN": "Se connecter"
+  },
   "ITEM_TEMPLATE_SELECTION_MODAL_TITLE": "Quel élément souhaitez-vous utiliser comme modèle pour les groupes ?",
   "ITEM_TEMPLATE_SELECTION_BUTTON": "Utiliser {{name}} comme modèle",
   "CREATE_ITEM_ADD_BUTTON": "Ajouter",

--- a/src/modules/builder/components/item/copy/CopyWarningModal.tsx
+++ b/src/modules/builder/components/item/copy/CopyWarningModal.tsx
@@ -1,0 +1,67 @@
+import { type JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from '@mui/material';
+
+import { useNavigate } from '@tanstack/react-router';
+
+import { NS } from '@/config/constants';
+import { LOG_IN_PAGE_PATH } from '@/config/paths';
+
+import useModalStatus from '~builder/components/hooks/useModalStatus';
+
+function CopyWarningModal({
+  itemName,
+}: Readonly<{
+  itemName: string;
+}>): JSX.Element {
+  const navigate = useNavigate();
+  const { t: translateCommon } = useTranslation(NS.Common);
+  const { t: translateBuilder } = useTranslation(NS.Builder, {
+    keyPrefix: 'COPY_WARNING_MODAL',
+  });
+  const { closeModal, isOpen } = useModalStatus({
+    isInitiallyOpen: true,
+  });
+
+  const redirectToLoginPage = () => {
+    navigate({
+      to: LOG_IN_PAGE_PATH,
+      search: {
+        url: window.location.href,
+      },
+    });
+  };
+
+  return (
+    <Dialog open={isOpen} onClose={closeModal}>
+      <DialogTitle>
+        {translateBuilder('TITLE', {
+          name: itemName,
+        })}
+      </DialogTitle>
+      <DialogContent>{translateBuilder('DESCRIPTION')}</DialogContent>
+
+      <DialogActions>
+        <Button onClick={closeModal}>
+          {translateCommon('CANCEL.BUTTON_TEXT')}
+        </Button>
+        <Button
+          aria-label={translateBuilder('LOGIN')}
+          variant="contained"
+          onClick={redirectToLoginPage}
+        >
+          {translateBuilder('LOGIN')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default CopyWarningModal;

--- a/src/modules/builder/components/item/header/Actions.tsx
+++ b/src/modules/builder/components/item/header/Actions.tsx
@@ -28,6 +28,8 @@ import FlagButton from '../../common/FlagButton';
 import HideButton from '../../common/HideButton';
 import PinButton from '../../common/PinButton';
 import RecycleButton from '../../common/RecycleButton';
+import CopyButton from '../copy/CopyButton';
+import { CopyModal } from '../copy/CopyModal';
 import CreateShortcutButton from '../shortcut/CreateShortcutButton';
 import CreateShortcutModal from '../shortcut/CreateShortcutModal';
 
@@ -58,6 +60,11 @@ const Actions = ({ item }: Props): JSX.Element[] | null => {
     openModal: openCreateShortcutModal,
     closeModal: closeCreateShortcutModal,
   } = useModalStatus();
+  const {
+    isOpen: isCopyModalOpen,
+    openModal: openCopyModal,
+    closeModal: closeCopyModal,
+  } = useModalStatus();
 
   const canWrite =
     item.permission &&
@@ -86,6 +93,11 @@ const Actions = ({ item }: Props): JSX.Element[] | null => {
     );
 
   return [
+    <CopyModal
+      onClose={closeCopyModal}
+      open={isCopyModalOpen}
+      items={[item]}
+    />,
     <CreateShortcutModal
       key="shortcutModal"
       item={item}
@@ -111,6 +123,14 @@ const Actions = ({ item }: Props): JSX.Element[] | null => {
     >
       {member.type === AccountType.Individual
         ? [
+            <CopyButton
+              key="copy"
+              type={ActionButton.MENU_ITEM}
+              onClick={() => {
+                openCopyModal();
+                closeMenu();
+              }}
+            />,
             <CreateShortcutButton
               key="shortcut"
               onClick={() => {
@@ -125,8 +145,8 @@ const Actions = ({ item }: Props): JSX.Element[] | null => {
               item={item}
               className={ITEM_MENU_BOOKMARK_BUTTON_CLASS}
             />,
+            <Divider key="downloadDivider" />,
             canWrite && [
-              <Divider key="canWriteDivider" />,
               <HideButton
                 key="hide"
                 type={ActionButton.MENU_ITEM}
@@ -140,8 +160,8 @@ const Actions = ({ item }: Props): JSX.Element[] | null => {
                   item={item}
                 />
               ),
+              <Divider key="canWriteDivider" />,
             ],
-            <Divider key="downloadDivider" />,
             downloadButton,
             <Divider key="canWriteEndDivider" />,
           ]

--- a/src/modules/builder/components/item/header/Actions.tsx
+++ b/src/modules/builder/components/item/header/Actions.tsx
@@ -11,6 +11,7 @@ import {
   PermissionLevelCompare,
 } from '@graasp/sdk';
 
+import { useSearch } from '@tanstack/react-router';
 import { MoreVerticalIcon } from 'lucide-react';
 
 import { NS } from '@/config/constants';
@@ -45,6 +46,7 @@ const internalId = 'menu';
  * or does not make sense in the context of the item
  */
 const Actions = ({ item }: Props): JSX.Element[] | null => {
+  const { copyOpen } = useSearch({ from: '/builder/items/$itemId' });
   const { t } = useTranslation(NS.Common, { keyPrefix: 'ARIA' });
   const { data: member } = hooks.useCurrentMember();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -64,7 +66,7 @@ const Actions = ({ item }: Props): JSX.Element[] | null => {
     isOpen: isCopyModalOpen,
     openModal: openCopyModal,
     closeModal: closeCopyModal,
-  } = useModalStatus();
+  } = useModalStatus({ isInitiallyOpen: copyOpen });
 
   const canWrite =
     item.permission &&

--- a/src/routes/builder/items/$itemId.tsx
+++ b/src/routes/builder/items/$itemId.tsx
@@ -53,6 +53,7 @@ import { GRAASP_MENU_ITEMS } from '~player/tree/TreeView';
 
 const schema = z.object({
   chatOpen: z.boolean().optional(),
+  copyOpen: z.boolean().optional(),
   mode: z.nativeEnum(ItemLayoutMode).optional(),
 });
 

--- a/src/routes/builder/items/$itemId/index.tsx
+++ b/src/routes/builder/items/$itemId/index.tsx
@@ -6,6 +6,7 @@ import { Divider, Stack, Typography } from '@mui/material';
 
 import { createFileRoute } from '@tanstack/react-router';
 
+import { useAuth } from '@/AuthContext';
 import { NS } from '@/config/constants';
 import { ITEM_MAIN_CLASS } from '@/config/selectors';
 import CustomInitialLoader from '@/ui/CustomInitialLoader/CustomInitialLoader';
@@ -14,6 +15,7 @@ import DrawerHeader from '@/ui/DrawerHeader/DrawerHeader';
 import Chatbox from '~builder/components/common/Chatbox';
 import { ItemContent } from '~builder/components/item/ItemContent';
 import ItemPanel from '~builder/components/item/ItemPanel';
+import CopyWarningModal from '~builder/components/item/copy/CopyWarningModal';
 import ItemHeader from '~builder/components/item/header/ItemHeader';
 import { useOutletContext } from '~builder/contexts/OutletContext';
 
@@ -24,7 +26,8 @@ export const Route = createFileRoute('/builder/items/$itemId/')({
 function RouteComponent(): JSX.Element {
   const { item } = useOutletContext();
   const { t: translateBuilder } = useTranslation(NS.Builder);
-  const { chatOpen: chatIsOpen } = Route.useSearch();
+  const { user: member } = useAuth();
+  const { chatOpen: chatIsOpen, copyOpen } = Route.useSearch();
 
   const [isChatboxOpen, setIsChatboxOpen] = useState(chatIsOpen ?? false);
   const toggleChatbox = () => setIsChatboxOpen((s) => !s);
@@ -35,6 +38,8 @@ function RouteComponent(): JSX.Element {
         <Helmet>
           <title>{item.name}</title>
         </Helmet>
+        {/* show copy modal warning if the user is not logged in */}
+        {copyOpen && !member ? <CopyWarningModal itemName={item.name} /> : null}
         <Stack direction="row" className={ITEM_MAIN_CLASS} height="100%">
           <Stack p={2} width="100%" maxWidth="xl" mx="auto">
             <ItemHeader

--- a/src/ui/buttons/CopyButton/CopyButton.tsx
+++ b/src/ui/buttons/CopyButton/CopyButton.tsx
@@ -34,7 +34,12 @@ const CopyButton = ({
   switch (type) {
     case ActionButton.MENU_ITEM:
       return (
-        <MenuItem key={text} onClick={onClick} className={menuItemClassName}>
+        <MenuItem
+          aria-label={text}
+          key={text}
+          onClick={onClick}
+          className={menuItemClassName}
+        >
           <ListItemIcon>{icon}</ListItemIcon>
           {text}
         </MenuItem>


### PR DESCRIPTION
Add copy item menu in item page. 
Otherwise it is not possible to copy the root (if you come from library for example)

<img width="1398" height="610" alt="Screenshot 2025-08-26 at 15 24 36" src="https://github.com/user-attachments/assets/02bbdf1e-1f6a-4f7e-b2d6-81ad6bc7da87" />
