### PR TITLE
fix: remove `waitForMutation` and use `await expect(...).rejects.toThrow()` on throwing mutations

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,7 +239,7 @@ importers:
         version: 19.8.1
       '@cypress/code-coverage':
         specifier: 3.14.5
-        version: 3.14.5(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(babel-loader@9.2.1(@babel/core@7.27.1)(webpack@5.97.1(esbuild@0.25.5)))(cypress@14.5.4)(webpack@5.97.1(esbuild@0.25.5))
+        version: 3.14.5(@babel/core@7.27.4)(@babel/preset-env@7.26.0(@babel/core@7.27.4))(babel-loader@9.2.1(@babel/core@7.27.4)(webpack@5.97.1(esbuild@0.25.5)))(cypress@14.5.4)(webpack@5.97.1(esbuild@0.25.5))
       '@eslint-react/eslint-plugin':
         specifier: 1.52.2
         version: 1.52.2(eslint@9.25.1(jiti@2.4.2))(ts-api-utils@2.1.0(typescript@5.8.3))(typescript@5.8.3)
@@ -440,7 +440,7 @@ importers:
         version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(terser@5.44.0)(tsx@4.20.3))
       vitest:
         specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.44.0)(tsx@4.20.3)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.44.0)(tsx@4.20.3)
 
 packages:
 
@@ -5038,8 +5038,8 @@ packages:
   jsbn@0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
 
-  jsdom@26.0.0:
-    resolution: {integrity: sha512-BZYDGVAIriBWTpIxYzrXjv3E/4u8+/pSG5bQdIYCbNCGOvsPkDQfTVLAIXAf9ETdCpduCVTkDe2NNZ8NIwUVzw==}
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
     engines: {node: '>=18'}
     peerDependencies:
       canvas: ^3.0.0
@@ -7428,29 +7428,29 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.3(@babel/core@7.27.1)':
+  '@babel/helper-create-class-features-plugin@7.28.3(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-member-expression-to-functions': 7.27.1
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.27.1)
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.27.4)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.28.3
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.27.1(@babel/core@7.27.1)':
+  '@babel/helper-create-regexp-features-plugin@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.2.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.27.1)':
+  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       debug: 4.4.1(supports-color@8.1.1)
@@ -7509,9 +7509,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.27.1)':
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
       '@babel/traverse': 7.28.3
@@ -7526,18 +7526,18 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.27.1)':
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.3
       '@babel/traverse': 7.28.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.27.1(@babel/core@7.27.1)':
+  '@babel/helper-replace-supers@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-member-expression-to-functions': 7.27.1
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/traverse': 7.28.3
@@ -7610,53 +7610,53 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.2
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.28.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.27.1)
+      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.27.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.27.1)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.28.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.27.1)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
 
-  '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.9)':
@@ -7669,268 +7669,268 @@ snapshots:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.27.1)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.27.1)
+      '@babel/core': 7.27.4
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.27.4)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.27.1)':
+  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.27.1)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.27.4)
       '@babel/traverse': 7.28.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.27.1)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.27.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-block-scoping@7.28.0(@babel/core@7.27.1)':
+  '@babel/plugin-transform-block-scoping@7.28.0(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.27.1)
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.28.3(@babel/core@7.27.1)':
-    dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.27.1)
+      '@babel/core': 7.27.4
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.27.4)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.3(@babel/core@7.27.1)':
+  '@babel/plugin-transform-class-static-block@7.28.3(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.27.4)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.28.3(@babel/core@7.27.4)':
+    dependencies:
+      '@babel/core': 7.27.4
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.27.1)
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.27.4)
       '@babel/traverse': 7.28.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/template': 7.27.2
 
-  '@babel/plugin-transform-destructuring@7.28.0(@babel/core@7.27.1)':
+  '@babel/plugin-transform-destructuring@7.28.0(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.28.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.27.1)
+      '@babel/core': 7.27.4
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.27.4)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.27.1)
+      '@babel/core': 7.27.4
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.27.4)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-exponentiation-operator@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-exponentiation-operator@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.28.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-logical-assignment-operators@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-logical-assignment-operators@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.27.1)
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.27.1)':
-    dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.27.1)
+      '@babel/core': 7.27.4
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.27.4)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.27.1)
+      '@babel/core': 7.27.4
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.27.4)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@7.27.1(@babel/core@7.27.4)':
+    dependencies:
+      '@babel/core': 7.27.4
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.27.4)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
       '@babel/traverse': 7.28.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.27.1)
+      '@babel/core': 7.27.4
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.27.4)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.27.1)
+      '@babel/core': 7.27.4
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.27.4)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-object-rest-spread@7.28.0(@babel/core@7.27.1)':
+  '@babel/plugin-transform-object-rest-spread@7.28.0(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.27.1)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.27.1)
+      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.27.4)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.27.4)
       '@babel/traverse': 7.28.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.27.1)
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.27.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-optional-chaining@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-optional-chaining@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.27.1)':
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.27.1)
+      '@babel/core': 7.27.4
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.27.4)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.27.1)
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.27.4)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.27.1)':
@@ -7943,151 +7943,151 @@ snapshots:
       '@babel/core': 7.27.1
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-regenerator@7.28.3(@babel/core@7.27.1)':
+  '@babel/plugin-transform-regenerator@7.28.3(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.27.1)
+      '@babel/core': 7.27.4
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.27.4)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-spread@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-spread@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.27.1)
+      '@babel/core': 7.27.4
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.27.4)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.27.1)
+      '@babel/core': 7.27.4
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.27.4)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.27.1)':
+  '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.27.1)
+      '@babel/core': 7.27.4
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.27.4)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/preset-env@7.26.0(@babel/core@7.27.1)':
+  '@babel/preset-env@7.26.0(@babel/core@7.27.4)':
     dependencies:
       '@babel/compat-data': 7.28.0
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.3(@babel/core@7.27.1)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.27.1)
-      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.27.1)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.27.1)
-      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-block-scoping': 7.28.0(@babel/core@7.27.1)
-      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.27.1)
-      '@babel/plugin-transform-classes': 7.28.3(@babel/core@7.27.1)
-      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.27.1)
-      '@babel/plugin-transform-dotall-regex': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-exponentiation-operator': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-json-strings': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-logical-assignment-operators': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-modules-systemjs': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-object-rest-spread': 7.28.0(@babel/core@7.27.1)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.27.1)
-      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-regenerator': 7.28.3(@babel/core@7.27.1)
-      '@babel/plugin-transform-regexp-modifiers': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-unicode-property-regex': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.27.1)
-      '@babel/plugin-transform-unicode-sets-regex': 7.27.1(@babel/core@7.27.1)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.27.1)
-      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.27.1)
-      babel-plugin-polyfill-corejs3: 0.10.6(@babel/core@7.27.1)
-      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.27.1)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.3(@babel/core@7.27.4)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.27.4)
+      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.27.4)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.27.4)
+      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-block-scoping': 7.28.0(@babel/core@7.27.4)
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.27.4)
+      '@babel/plugin-transform-classes': 7.28.3(@babel/core@7.27.4)
+      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.27.4)
+      '@babel/plugin-transform-dotall-regex': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-exponentiation-operator': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-json-strings': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-logical-assignment-operators': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-modules-systemjs': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-object-rest-spread': 7.28.0(@babel/core@7.27.4)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.27.4)
+      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-regenerator': 7.28.3(@babel/core@7.27.4)
+      '@babel/plugin-transform-regexp-modifiers': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-unicode-property-regex': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.27.4)
+      '@babel/plugin-transform-unicode-sets-regex': 7.27.1(@babel/core@7.27.4)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.27.4)
+      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.27.4)
+      babel-plugin-polyfill-corejs3: 0.10.6(@babel/core@7.27.4)
+      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.27.4)
       core-js-compat: 3.45.1
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.27.1)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.27.4)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/types': 7.28.2
       esutils: 2.0.3
@@ -8370,12 +8370,12 @@ snapshots:
   '@csstools/css-tokenizer@3.0.4':
     optional: true
 
-  '@cypress/code-coverage@3.14.5(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(babel-loader@9.2.1(@babel/core@7.27.1)(webpack@5.97.1(esbuild@0.25.5)))(cypress@14.5.4)(webpack@5.97.1(esbuild@0.25.5))':
+  '@cypress/code-coverage@3.14.5(@babel/core@7.27.4)(@babel/preset-env@7.26.0(@babel/core@7.27.4))(babel-loader@9.2.1(@babel/core@7.27.4)(webpack@5.97.1(esbuild@0.25.5)))(cypress@14.5.4)(webpack@5.97.1(esbuild@0.25.5))':
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/preset-env': 7.26.0(@babel/core@7.27.1)
-      '@cypress/webpack-preprocessor': 6.0.4(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(babel-loader@9.2.1(@babel/core@7.27.1)(webpack@5.97.1(esbuild@0.25.5)))(webpack@5.97.1(esbuild@0.25.5))
-      babel-loader: 9.2.1(@babel/core@7.27.1)(webpack@5.97.1(esbuild@0.25.5))
+      '@babel/core': 7.27.4
+      '@babel/preset-env': 7.26.0(@babel/core@7.27.4)
+      '@cypress/webpack-preprocessor': 6.0.4(@babel/core@7.27.4)(@babel/preset-env@7.26.0(@babel/core@7.27.4))(babel-loader@9.2.1(@babel/core@7.27.4)(webpack@5.97.1(esbuild@0.25.5)))(webpack@5.97.1(esbuild@0.25.5))
+      babel-loader: 9.2.1(@babel/core@7.27.4)(webpack@5.97.1(esbuild@0.25.5))
       chalk: 4.1.2
       cypress: 14.5.4
       dayjs: 1.11.13
@@ -8410,11 +8410,11 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 8.3.2
 
-  '@cypress/webpack-preprocessor@6.0.4(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(babel-loader@9.2.1(@babel/core@7.27.1)(webpack@5.97.1(esbuild@0.25.5)))(webpack@5.97.1(esbuild@0.25.5))':
+  '@cypress/webpack-preprocessor@6.0.4(@babel/core@7.27.4)(@babel/preset-env@7.26.0(@babel/core@7.27.4))(babel-loader@9.2.1(@babel/core@7.27.4)(webpack@5.97.1(esbuild@0.25.5)))(webpack@5.97.1(esbuild@0.25.5))':
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/preset-env': 7.26.0(@babel/core@7.27.1)
-      babel-loader: 9.2.1(@babel/core@7.27.1)(webpack@5.97.1(esbuild@0.25.5))
+      '@babel/core': 7.27.4
+      '@babel/preset-env': 7.26.0(@babel/core@7.27.4)
+      babel-loader: 9.2.1(@babel/core@7.27.4)(webpack@5.97.1(esbuild@0.25.5))
       bluebird: 3.7.1
       debug: 4.4.1(supports-color@8.1.1)
       lodash: 4.17.21
@@ -9549,7 +9549,7 @@ snapshots:
     optionalDependencies:
       '@vitest/browser': 3.2.4(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(terser@5.44.0)(tsx@4.20.3))(vitest@3.2.4)
       '@vitest/runner': 3.2.4
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.44.0)(tsx@4.20.3)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.44.0)(tsx@4.20.3)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -10195,7 +10195,7 @@ snapshots:
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.44.0)(tsx@4.20.3)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.44.0)(tsx@4.20.3)
       ws: 8.18.2
     optionalDependencies:
       playwright: 1.52.0
@@ -10255,7 +10255,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.44.0)(tsx@4.20.3)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.44.0)(tsx@4.20.3)
 
   '@vitest/utils@3.1.4':
     dependencies:
@@ -10567,9 +10567,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.27.1)(webpack@5.97.1(esbuild@0.25.5)):
+  babel-loader@9.2.1(@babel/core@7.27.4)(webpack@5.97.1(esbuild@0.25.5)):
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.27.4
       find-cache-dir: 4.0.0
       schema-utils: 4.3.2
       webpack: 5.97.1(esbuild@0.25.5)
@@ -10580,27 +10580,27 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.10
 
-  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.27.1):
+  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.27.4):
     dependencies:
       '@babel/compat-data': 7.28.0
-      '@babel/core': 7.27.1
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.27.1)
+      '@babel/core': 7.27.4
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.27.4)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.10.6(@babel/core@7.27.1):
+  babel-plugin-polyfill-corejs3@0.10.6(@babel/core@7.27.4):
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.27.1)
+      '@babel/core': 7.27.4
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.27.4)
       core-js-compat: 3.45.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.27.1):
+  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.27.4):
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.27.1)
+      '@babel/core': 7.27.4
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.27.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -12598,12 +12598,11 @@ snapshots:
 
   jsbn@0.1.1: {}
 
-  jsdom@26.0.0:
+  jsdom@26.1.0:
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
-      form-data: 4.0.4
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -14981,7 +14980,7 @@ snapshots:
       terser: 5.44.0
       tsx: 4.20.3
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.44.0)(tsx@4.20.3):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/browser@3.2.4)(@vitest/ui@3.1.4)(happy-dom@18.0.1)(jiti@2.4.2)(jsdom@26.1.0)(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(terser@5.44.0)(tsx@4.20.3):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -15012,7 +15011,7 @@ snapshots:
       '@vitest/browser': 3.2.4(msw@2.7.0(@types/node@22.15.3)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(terser@5.44.0)(tsx@4.20.3))(vitest@3.2.4)
       '@vitest/ui': 3.1.4(vitest@3.2.4)
       happy-dom: 18.0.1
-      jsdom: 26.0.0
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
       - less

--- a/src/query/hooks/useDebounce.ts
+++ b/src/query/hooks/useDebounce.ts
@@ -9,7 +9,7 @@ export default function useDebounce<T>(value: T, delay: number) {
   useEffect(
     () => {
       // Update debounced value after delay
-      const handler = setTimeout(() => {
+      const handler = globalThis.setTimeout(() => {
         setDebouncedValue(value);
       }, delay);
 
@@ -17,7 +17,7 @@ export default function useDebounce<T>(value: T, delay: number) {
       // This is how we prevent debounced value from updating if value is changed ...
       // .. within the delay period. Timeout gets cleared and restarted.
       return () => {
-        clearTimeout(handler);
+        globalThis.clearTimeout(handler);
       };
     },
     [value, delay], // Only re-call effect if value or delay changes

--- a/src/query/item/create/mutations.test.ts
+++ b/src/query/item/create/mutations.test.ts
@@ -14,7 +14,7 @@ import {
   ITEM_GEOLOCATION,
   UNAUTHORIZED_RESPONSE,
 } from '../../test/constants.js';
-import { mockMutation, setUpTest, waitForMutation } from '../../test/utils.js';
+import { mockMutation, setUpTest } from '../../test/utils.js';
 import {
   buildPostItemRoute,
   buildPostItemWithThumbnailRoute,
@@ -57,8 +57,7 @@ describe('usePostItem', () => {
     });
 
     await act(async () => {
-      mockedMutation.mutate(newItem);
-      await waitForMutation();
+      await mockedMutation.mutateAsync(newItem);
     });
 
     expect(
@@ -94,8 +93,7 @@ describe('usePostItem', () => {
     });
 
     await act(async () => {
-      mockedMutation.mutate({ ...newItem, parentId: parentItem.id });
-      await waitForMutation();
+      await mockedMutation.mutateAsync({ ...newItem, parentId: parentItem.id });
     });
 
     expect(
@@ -139,12 +137,11 @@ describe('usePostItem', () => {
     });
 
     await act(async () => {
-      mockedMutation.mutate({
+      await mockedMutation.mutateAsync({
         ...newItem,
         parentId: parentItem.id,
         geolocation: { lat: 1, lng: 1 },
       });
-      await waitForMutation();
     });
 
     expect(
@@ -188,11 +185,10 @@ describe('usePostItem', () => {
     });
 
     await act(async () => {
-      mockedMutation.mutate({
+      await mockedMutation.mutateAsync({
         ...newItemWithThumbnail,
         parentId: parentItem.id,
       });
-      await waitForMutation();
     });
 
     expect(
@@ -230,12 +226,11 @@ describe('usePostItem', () => {
     });
 
     await act(async () => {
-      mockedMutation.mutate({
+      await mockedMutation.mutateAsync({
         ...newItem,
         parentId: parentItem.id,
         previousItemId: previousItem.id,
       });
-      await waitForMutation();
     });
 
     expect(
@@ -263,10 +258,7 @@ describe('usePostItem', () => {
       wrapper,
     });
 
-    await act(async () => {
-      mockedMutation.mutate(newItem);
-      await waitForMutation();
-    });
+    await expect(mockedMutation.mutateAsync(newItem)).rejects.toThrow();
 
     expect(
       queryClient.getQueryState(itemKeys.allAccessible())?.isInvalidated,
@@ -306,10 +298,9 @@ describe('useUploadFiles', () => {
     });
 
     await act(async () => {
-      mockedMutation.mutate({
+      await mockedMutation.mutateAsync({
         files: [new File([], 'name')],
       });
-      await waitForMutation();
     });
 
     // notification of a big file
@@ -344,11 +335,10 @@ describe('useUploadFiles', () => {
     });
 
     await act(async () => {
-      mockedMutation.mutate({
+      await mockedMutation.mutateAsync({
         id: parentId,
         files: [new File([], 'name')],
       });
-      await waitForMutation();
     });
 
     // notification of a big file
@@ -382,12 +372,11 @@ describe('useUploadFiles', () => {
     });
 
     await act(async () => {
-      mockedMutation.mutate({
+      await mockedMutation.mutateAsync({
         id: parentId,
         previousItemId,
         files: [new File([], 'name')],
       });
-      await waitForMutation();
     });
 
     // notification of a big file
@@ -417,14 +406,13 @@ describe('useUploadFiles', () => {
     });
 
     await act(async () => {
-      mockedMutation.mutate({
+      await mockedMutation.mutateAsync({
         files: [
           new File([], 'name'),
           new File([], 'name'),
           new File([], 'name'),
         ],
       });
-      await waitForMutation();
     });
 
     expect(
@@ -449,12 +437,11 @@ describe('useUploadFiles', () => {
       wrapper,
     });
 
-    await act(async () => {
-      mockedMutation.mutate({
+    await expect(
+      mockedMutation.mutateAsync({
         files: [],
-      });
-      await waitForMutation();
-    });
+      }),
+    ).rejects.toThrow();
 
     // notification of a big file
     expect(mockedNotifier).toHaveBeenCalledWith(
@@ -485,11 +472,8 @@ describe('useUploadFiles', () => {
     const file = new File([], 'name');
     Object.defineProperty(file, 'size', { value: sdk.MAX_FILE_SIZE + 10 });
 
-    await act(async () => {
-      mockedMutation.mutate({
-        files: [file, new File([], 'name'), new File([], 'name')],
-      });
-      await waitForMutation();
+    await mockedMutation.mutateAsync({
+      files: [file, new File([], 'name'), new File([], 'name')],
     });
 
     // notification of a big file
@@ -526,8 +510,7 @@ describe('useUploadFiles', () => {
     });
 
     await act(async () => {
-      mockedMutation.mutate({ files: [new File([], 'name')] });
-      await waitForMutation();
+      await mockedMutation.mutateAsync({ files: [new File([], 'name')] });
     });
 
     expect(

--- a/src/query/item/h5p/mutations.test.ts
+++ b/src/query/item/h5p/mutations.test.ts
@@ -1,6 +1,5 @@
 import { H5PItemFactory, HttpMethod } from '@graasp/sdk';
 
-import { act } from '@testing-library/react';
 import { StatusCodes } from 'http-status-codes';
 import { v4 } from 'uuid';
 import { describe, expect, it, vi } from 'vitest';
@@ -8,7 +7,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { itemKeys } from '../../keys.js';
 import { buildImportH5PRoute } from '../../routes.js';
 import { UNAUTHORIZED_RESPONSE } from '../../test/constants.js';
-import { mockMutation, setUpTest, waitForMutation } from '../../test/utils.js';
+import { mockMutation, setUpTest } from '../../test/utils.js';
 import { importH5PRoutine } from '../routines.js';
 
 const mockedNotifier = vi.fn();
@@ -42,11 +41,8 @@ describe('useImportH5P', () => {
       wrapper,
     });
 
-    await act(async () => {
-      mockedMutation.mutate({
-        file,
-      });
-      await waitForMutation();
+    await mockedMutation.mutateAsync({
+      file,
     });
 
     // notification of a big file
@@ -76,12 +72,9 @@ describe('useImportH5P', () => {
       wrapper,
     });
 
-    await act(async () => {
-      mockedMutation.mutate({
-        file,
-        id: item.id,
-      });
-      await waitForMutation();
+    await mockedMutation.mutateAsync({
+      file,
+      id: item.id,
     });
 
     // notification of a big file
@@ -113,13 +106,10 @@ describe('useImportH5P', () => {
       wrapper,
     });
 
-    await act(async () => {
-      mockedMutation.mutate({
-        file,
-        id: item.id,
-        previousItemId,
-      });
-      await waitForMutation();
+    await mockedMutation.mutateAsync({
+      file,
+      id: item.id,
+      previousItemId,
     });
 
     // notification of a big file
@@ -153,10 +143,7 @@ describe('useImportH5P', () => {
       wrapper,
     });
 
-    await act(async () => {
-      mockedMutation.mutate({ file });
-      await waitForMutation();
-    });
+    await expect(mockedMutation.mutateAsync({ file })).rejects.toThrow();
 
     expect(mockedNotifier).toHaveBeenCalledWith(
       expect.objectContaining({ type: importH5PRoutine.FAILURE }),

--- a/src/query/item/import-zip/mutations.test.ts
+++ b/src/query/item/import-zip/mutations.test.ts
@@ -1,12 +1,11 @@
 import { HttpMethod } from '@graasp/sdk';
 
-import { act } from '@testing-library/react';
 import { StatusCodes } from 'http-status-codes';
 import { describe, expect, it, vi } from 'vitest';
 
 import { buildImportZipRoute } from '../../routes.js';
 import { UNAUTHORIZED_RESPONSE } from '../../test/constants.js';
-import { mockMutation, setUpTest, waitForMutation } from '../../test/utils.js';
+import { mockMutation, setUpTest } from '../../test/utils.js';
 import { importZipRoutine } from '../routines.js';
 
 const mockedNotifier = vi.fn();
@@ -38,11 +37,8 @@ describe('useImportZip', () => {
       wrapper,
     });
 
-    await act(async () => {
-      mockedMutation.mutate({
-        file,
-      });
-      await waitForMutation();
+    await mockedMutation.mutateAsync({
+      file,
     });
 
     expect(mockedNotifier).toHaveBeenCalledWith({
@@ -66,12 +62,9 @@ describe('useImportZip', () => {
       wrapper,
     });
 
-    await act(async () => {
-      mockedMutation.mutate({
-        file,
-        id: item.id,
-      });
-      await waitForMutation();
+    await mockedMutation.mutateAsync({
+      file,
+      id: item.id,
     });
 
     expect(mockedNotifier).toHaveBeenCalledWith({
@@ -98,10 +91,7 @@ describe('useImportZip', () => {
       wrapper,
     });
 
-    await act(async () => {
-      mockedMutation.mutate({ file });
-      await waitForMutation();
-    });
+    await expect(mockedMutation.mutateAsync({ file })).rejects.toThrow();
 
     expect(mockedNotifier).toHaveBeenCalledWith(
       expect.objectContaining({ type: importZipRoutine.FAILURE }),

--- a/src/query/item/mutations.test.ts
+++ b/src/query/item/mutations.test.ts
@@ -8,7 +8,6 @@ import {
   getParentFromPath,
 } from '@graasp/sdk';
 
-import { act } from '@testing-library/react';
 import { StatusCodes } from 'http-status-codes';
 import nock from 'nock';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -20,12 +19,7 @@ import {
   UNAUTHORIZED_RESPONSE,
   generateFolders,
 } from '../test/constants.js';
-import {
-  mockMutation,
-  setUpTest,
-  splitEndpointByIds,
-  waitForMutation,
-} from '../test/utils.js';
+import { mockMutation, setUpTest, splitEndpointByIds } from '../test/utils.js';
 import {
   buildCopyItemsRoute,
   buildDeleteItemsRoute,
@@ -78,10 +72,7 @@ describe('Items Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate(payload);
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync(payload);
 
       expect(queryClient.getQueryState(itemKey)?.isInvalidated).toBeTruthy();
       expect(
@@ -109,10 +100,7 @@ describe('Items Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate(payload);
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync(payload);
 
       expect(
         queryClient.getQueryState(itemKeys.allAccessible())?.isInvalidated,
@@ -148,10 +136,7 @@ describe('Items Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate(editPayload);
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync(editPayload);
 
       expect(
         queryClient.getQueryState(editedItemKey)?.isInvalidated,
@@ -178,10 +163,7 @@ describe('Items Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate(payload);
-        await waitForMutation();
-      });
+      await expect(mockedMutation.mutateAsync(payload)).rejects.toThrow();
 
       // item key should not be changed and should be invalidated
       expect(
@@ -229,12 +211,9 @@ describe('Items Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
-          to,
-          ids: copiedIds,
-        });
-        await waitForMutation();
+      await mockedMutation.mutateAsync({
+        to,
+        ids: copiedIds,
       });
 
       // original copied items path have not changed
@@ -286,12 +265,9 @@ describe('Items Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
-          to: toId,
-          items: moved,
-        });
-        await waitForMutation();
+      await mockedMutation.mutateAsync({
+        to: toId,
+        items: moved,
       });
 
       // Check new path are corrects
@@ -338,12 +314,9 @@ describe('Items Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
-          to: toId,
-          items: moved,
-        });
-        await waitForMutation();
+      await mockedMutation.mutateAsync({
+        to: toId,
+        items: moved,
       });
 
       // Check new paths are corrects
@@ -394,10 +367,7 @@ describe('Items Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate(itemIds);
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync(itemIds);
 
       // verify item is still available
       // in real cases, the path should be different
@@ -451,10 +421,7 @@ describe('Items Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate(itemIds);
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync(itemIds);
 
       // verify item is still available
       // in real cases, the path should be different
@@ -513,10 +480,7 @@ describe('Items Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate(itemIds);
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync(itemIds);
 
       // verify item is still available
       // in real cases, the path should be different
@@ -557,10 +521,7 @@ describe('Items Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate(itemIds);
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync(itemIds);
 
       // verify items are not available
       // in real cases, the path should be different
@@ -609,10 +570,7 @@ describe('Items Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate(itemIds);
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync(itemIds);
 
       // verify item is still available
       // in real cases, the path should be different
@@ -668,10 +626,7 @@ describe('Items Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate(itemIds);
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync(itemIds);
 
       // verify item is still available
       // in real cases, the path should be different

--- a/src/query/item/reorder/mutations.test.ts
+++ b/src/query/item/reorder/mutations.test.ts
@@ -1,6 +1,5 @@
 import { FolderItemFactory, HttpMethod } from '@graasp/sdk';
 
-import { act } from '@testing-library/react';
 import { StatusCodes } from 'http-status-codes';
 import nock from 'nock';
 import { v4 } from 'uuid';
@@ -8,7 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { itemKeys } from '../../keys.js';
 import { UNAUTHORIZED_RESPONSE } from '../../test/constants.js';
-import { mockMutation, setUpTest, waitForMutation } from '../../test/utils.js';
+import { mockMutation, setUpTest } from '../../test/utils.js';
 import { buildReorderItemRoute } from '../routes.js';
 import { reorderItemRoutine } from '../routines.js';
 
@@ -52,9 +51,10 @@ describe('useReorderItem', () => {
       wrapper,
     });
 
-    await act(async () => {
-      mockedMutation.mutate({ id: child.id, parentItemId, previousItemId });
-      await waitForMutation();
+    await mockedMutation.mutateAsync({
+      id: child.id,
+      parentItemId,
+      previousItemId,
     });
 
     const state = queryClient.getQueryState(key);
@@ -88,10 +88,13 @@ describe('useReorderItem', () => {
       wrapper,
     });
 
-    await act(async () => {
-      mockedMutation.mutate({ id: child.id, parentItemId, previousItemId });
-      await waitForMutation();
-    });
+    await expect(
+      mockedMutation.mutateAsync({
+        id: child.id,
+        parentItemId,
+        previousItemId,
+      }),
+    ).rejects.toThrow();
 
     const state = queryClient.getQueryState(key);
     expect(state?.isInvalidated).toBeTruthy();

--- a/src/query/item/thumbnail/mutations.test.ts
+++ b/src/query/item/thumbnail/mutations.test.ts
@@ -1,6 +1,5 @@
 import { HttpMethod, MAX_FILE_SIZE } from '@graasp/sdk';
 
-import { act } from '@testing-library/react';
 import { StatusCodes } from 'http-status-codes';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -9,7 +8,7 @@ import {
   UNAUTHORIZED_RESPONSE,
   generateFolders,
 } from '../../test/constants.js';
-import { mockMutation, setUpTest, waitForMutation } from '../../test/utils.js';
+import { mockMutation, setUpTest } from '../../test/utils.js';
 import {
   buildDeleteItemThumbnailRoute,
   buildUploadItemThumbnailRoute,
@@ -50,10 +49,7 @@ describe('useDeleteItemThumbnail', () => {
       wrapper,
     });
 
-    await act(async () => {
-      mockedMutation.mutate(itemId);
-      await waitForMutation();
-    });
+    await mockedMutation.mutateAsync(itemId);
 
     expect(
       queryClient.getQueryState(itemKeys.single(itemId).allThumbnails)
@@ -96,12 +92,9 @@ describe('useUploadItemThumbnail', () => {
       wrapper,
     });
 
-    await act(async () => {
-      mockedMutation.mutate({
-        file,
-        id: item.id,
-      });
-      await waitForMutation();
+    await mockedMutation.mutateAsync({
+      file,
+      id: item.id,
     });
 
     expect(
@@ -133,13 +126,12 @@ describe('useUploadItemThumbnail', () => {
     const bigFile = new Blob([]);
     Object.defineProperty(bigFile, 'size', { value: MAX_FILE_SIZE + 10 });
 
-    await act(async () => {
-      mockedMutation.mutate({
+    await expect(
+      mockedMutation.mutateAsync({
         file: bigFile,
         id: item.id,
-      });
-      await waitForMutation();
-    });
+      }),
+    ).rejects.toThrow();
 
     // notification of a big file
     expect(mockedNotifier).toHaveBeenCalledWith(
@@ -172,10 +164,7 @@ describe('useUploadItemThumbnail', () => {
       wrapper,
     });
 
-    await act(async () => {
-      mockedMutation.mutate({ file, id: item.id });
-      await waitForMutation();
-    });
+    await mockedMutation.mutateAsync({ file, id: item.id });
 
     expect(mockedNotifier).toHaveBeenCalledWith(
       expect.objectContaining({ type: uploadItemThumbnailRoutine.FAILURE }),

--- a/src/query/member/mutations.test.ts
+++ b/src/query/member/mutations.test.ts
@@ -1,13 +1,12 @@
 import { HttpMethod, MemberFactory, ThumbnailSize } from '@graasp/sdk';
 
-import { act } from '@testing-library/react';
 import { StatusCodes } from 'http-status-codes';
 import nock from 'nock';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { memberKeys } from '../keys.js';
 import { UNAUTHORIZED_RESPONSE } from '../test/constants.js';
-import { mockMutation, setUpTest, waitForMutation } from '../test/utils.js';
+import { mockMutation, setUpTest } from '../test/utils.js';
 import { buildUploadAvatarRoute } from './routes.js';
 import { uploadAvatarRoutine } from './routines.js';
 
@@ -55,10 +54,7 @@ describe('Member Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ file });
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync({ file });
 
       for (const size of Object.values(ThumbnailSize)) {
         const key = memberKeys.single(id).avatar({ size, replyUrl: true });
@@ -97,10 +93,7 @@ describe('Member Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ file });
-        await waitForMutation();
-      });
+      await expect(mockedMutation.mutateAsync({ file })).rejects.toThrow();
 
       for (const size of Object.values(ThumbnailSize)) {
         const key = memberKeys.single(id).avatar({ size, replyUrl });

--- a/src/query/mutations/invitation.test.ts
+++ b/src/query/mutations/invitation.test.ts
@@ -1,6 +1,5 @@
 import { FolderItemFactory, HttpMethod, Invitation } from '@graasp/sdk';
 
-import { act } from '@testing-library/react';
 import { StatusCodes } from 'http-status-codes';
 import nock from 'nock';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -24,7 +23,7 @@ import {
   buildInvitation,
   buildMockInvitations,
 } from '../test/constants.js';
-import { mockMutation, setUpTest, waitForMutation } from '../test/utils.js';
+import { mockMutation, setUpTest } from '../test/utils.js';
 
 const item = FolderItemFactory();
 const itemId = item.id;
@@ -70,9 +69,9 @@ describe('Invitations Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ itemId, invitations: [newInvitation] });
-        await waitForMutation();
+      await mockedMutation.mutateAsync({
+        itemId,
+        invitations: [newInvitation],
       });
 
       // check memberships invalidation
@@ -106,10 +105,7 @@ describe('Invitations Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ itemId, invitations: newInvitations });
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync({ itemId, invitations: newInvitations });
 
       // check memberships invalidation
       const data = queryClient.getQueryState(key);
@@ -137,10 +133,12 @@ describe('Invitations Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ itemId, invitations: [newInvitation] });
-        await waitForMutation();
-      });
+      await expect(
+        mockedMutation.mutateAsync({
+          itemId,
+          invitations: [newInvitation],
+        }),
+      ).rejects.toThrow();
 
       // check memberships invalidation
       const data = queryClient.getQueryState(key);
@@ -171,9 +169,9 @@ describe('Invitations Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ itemId, invitations: [newInvitation] });
-        await waitForMutation();
+      await mockedMutation.mutateAsync({
+        itemId,
+        invitations: [newInvitation],
       });
 
       // check memberships invalidation
@@ -221,10 +219,7 @@ describe('Invitations Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ ...newInvitation, itemId });
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync({ ...newInvitation, itemId });
 
       // check memberships invalidation
       const data = queryClient.getQueryState(key);
@@ -253,11 +248,9 @@ describe('Invitations Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ ...newInvitation, itemId });
-        await waitForMutation();
-      });
-
+      await expect(
+        mockedMutation.mutateAsync({ ...newInvitation, itemId }),
+      ).rejects.toThrow();
       // check memberships invalidation
       const data = queryClient.getQueryState(key);
       expect(data?.isInvalidated).toBeTruthy();
@@ -304,10 +297,7 @@ describe('Invitations Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ id: invitationToDelete.id, itemId });
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync({ id: invitationToDelete.id, itemId });
 
       // check memberships invalidation
       const state = queryClient.getQueryState(key);
@@ -342,10 +332,9 @@ describe('Invitations Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ id: invitationToDelete.id, itemId });
-        await waitForMutation();
-      });
+      await expect(
+        mockedMutation.mutateAsync({ id: invitationToDelete.id, itemId }),
+      ).rejects.toThrow();
 
       // check memberships invalidation
       const state = queryClient.getQueryState(key);
@@ -386,10 +375,7 @@ describe('Invitations Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ id: invitation.id, itemId });
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync({ id: invitation.id, itemId });
 
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: resendInvitationRoutine.SUCCESS,
@@ -412,10 +398,9 @@ describe('Invitations Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ id: invitation.id, itemId });
-        await waitForMutation();
-      });
+      await expect(
+        mockedMutation.mutateAsync({ id: invitation.id, itemId }),
+      ).rejects.toThrow();
 
       expect(mockedNotifier).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/query/mutations/itemExport.test.ts
+++ b/src/query/mutations/itemExport.test.ts
@@ -1,12 +1,11 @@
 import { HttpMethod } from '@graasp/sdk';
 
-import { act } from '@testing-library/react';
 import nock from 'nock';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { buildExportItemRoute } from '../routes.js';
 import { exportItemRoutine } from '../routines/itemExport.js';
-import { mockMutation, setUpTest, waitForMutation } from '../test/utils.js';
+import { mockMutation, setUpTest } from '../test/utils.js';
 
 const mockedNotifier = vi.fn();
 const { wrapper, queryClient, mutations } = setUpTest({
@@ -41,10 +40,7 @@ describe('Export Item', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ id: itemId });
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync({ id: itemId });
 
       expect(mockedNotifier).toHaveBeenCalledWith({
         type: exportItemRoutine.SUCCESS,

--- a/src/query/mutations/itemGeolocation.test.ts
+++ b/src/query/mutations/itemGeolocation.test.ts
@@ -1,6 +1,5 @@
 import { HttpMethod } from '@graasp/sdk';
 
-import { act } from '@testing-library/react';
 import { StatusCodes } from 'http-status-codes';
 import nock from 'nock';
 import { v4 } from 'uuid';
@@ -13,7 +12,7 @@ import {
   putItemGeolocationRoutine,
 } from '../routines/itemGeolocation.js';
 import { ITEM_GEOLOCATION, UNAUTHORIZED_RESPONSE } from '../test/constants.js';
-import { mockMutation, setUpTest, waitForMutation } from '../test/utils.js';
+import { mockMutation, setUpTest } from '../test/utils.js';
 
 const mockedNotifier = vi.fn();
 const { wrapper, queryClient, mutations } = setUpTest({
@@ -60,17 +59,14 @@ describe('Item Flag Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
-          geolocation: {
-            lat: 1,
-            lng: 1,
-            addressLabel: 'address',
-            country: 'country',
-          },
-          itemId,
-        });
-        await waitForMutation();
+      await mockedMutation.mutateAsync({
+        geolocation: {
+          lat: 1,
+          lng: 1,
+          addressLabel: 'address',
+          country: 'country',
+        },
+        itemId,
       });
 
       expect(queryClient.getQueryState(key)?.isInvalidated).toBeTruthy();
@@ -102,12 +98,9 @@ describe('Item Flag Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
-          geolocation: { lat: 1, lng: 1 },
-          itemId,
-        });
-        await waitForMutation();
+      await mockedMutation.mutateAsync({
+        geolocation: { lat: 1, lng: 1 },
+        itemId,
       });
 
       expect(queryClient.getQueryState(key)?.isInvalidated).toBeTruthy();
@@ -139,12 +132,9 @@ describe('Item Flag Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
-          geolocation: { lat: 1, lng: 2, helperLabel: 'helperlabel' },
-          itemId,
-        });
-        await waitForMutation();
+      await mockedMutation.mutateAsync({
+        geolocation: { lat: 1, lng: 2, helperLabel: 'helperlabel' },
+        itemId,
       });
 
       expect(queryClient.getQueryState(key)?.isInvalidated).toBeTruthy();
@@ -175,13 +165,12 @@ describe('Item Flag Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
+      await expect(
+        mockedMutation.mutateAsync({
           geolocation: { lat: 1, lng: 1 },
           itemId,
-        });
-        await waitForMutation();
-      });
+        }),
+      ).rejects.toThrow();
 
       expect(queryClient.getQueryState(key)?.isInvalidated).toBeTruthy();
       expect(queryClient.getQueryState(singleKey)?.isInvalidated).toBeTruthy();
@@ -227,10 +216,7 @@ describe('Item Flag Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ itemId });
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync({ itemId });
 
       expect(queryClient.getQueryState(key)?.isInvalidated).toBeTruthy();
       expect(queryClient.getQueryState(singleKey)?.isInvalidated).toBeTruthy();
@@ -260,10 +246,7 @@ describe('Item Flag Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ itemId });
-        await waitForMutation();
-      });
+      await expect(mockedMutation.mutateAsync({ itemId })).rejects.toThrow();
 
       expect(queryClient.getQueryState(key)?.isInvalidated).toBeTruthy();
       expect(queryClient.getQueryState(singleKey)?.isInvalidated).toBeTruthy();

--- a/src/query/mutations/itemLogin.test.ts
+++ b/src/query/mutations/itemLogin.test.ts
@@ -7,7 +7,6 @@ import {
   MemberFactory,
 } from '@graasp/sdk';
 
-import { act } from '@testing-library/react';
 import { StatusCodes } from 'http-status-codes';
 import nock from 'nock';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -24,7 +23,7 @@ import {
   putItemLoginSchemaRoutine,
 } from '../routines/itemLogin.js';
 import { ITEM_LOGIN_RESPONSE } from '../test/constants.js';
-import { mockMutation, setUpTest, waitForMutation } from '../test/utils.js';
+import { mockMutation, setUpTest } from '../test/utils.js';
 
 const mockedNotifier = vi.fn();
 const { wrapper, queryClient, mutations } = setUpTest({
@@ -63,14 +62,11 @@ describe('Item Login Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
-          itemId,
-          username,
-          memberId,
-          password,
-        });
-        await waitForMutation();
+      await mockedMutation.mutateAsync({
+        itemId,
+        username,
+        memberId,
+        password,
       });
 
       // check all set keys are reset
@@ -101,15 +97,14 @@ describe('Item Login Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
+      await expect(
+        mockedMutation.mutateAsync({
           itemId,
           username,
           memberId,
           password,
-        });
-        await waitForMutation();
-      });
+        }),
+      ).rejects.toThrow();
 
       // check all set keys are reset
       expect(
@@ -151,10 +146,7 @@ describe('Item Login Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ itemId, type: newLoginSchema });
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync({ itemId, type: newLoginSchema });
 
       // check all set keys are reset
       expect(
@@ -183,12 +175,9 @@ describe('Item Login Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
-          itemId,
-          status: ItemLoginSchemaStatus.Disabled,
-        });
-        await waitForMutation();
+      await mockedMutation.mutateAsync({
+        itemId,
+        status: ItemLoginSchemaStatus.Disabled,
       });
 
       // check all set keys are reset
@@ -219,13 +208,12 @@ describe('Item Login Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
+      await expect(
+        mockedMutation.mutateAsync({
           itemId,
           type: newLoginSchema,
-        });
-        await waitForMutation();
-      });
+        }),
+      ).rejects.toThrow();
 
       // check all set keys are reset
       expect(
@@ -264,10 +252,7 @@ describe('Item Login Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ itemId });
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync({ itemId });
 
       // check all set keys are reset
       expect(
@@ -303,12 +288,11 @@ describe('Item Login Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
+      await expect(
+        mockedMutation.mutateAsync({
           itemId,
-        });
-        await waitForMutation();
-      });
+        }),
+      ).rejects.toThrow();
 
       // check all set keys are reset
       expect(

--- a/src/query/mutations/itemPublish.test.ts
+++ b/src/query/mutations/itemPublish.test.ts
@@ -5,7 +5,6 @@ import {
   PublicationStatus,
 } from '@graasp/sdk';
 
-import { act } from '@testing-library/react';
 import { StatusCodes } from 'http-status-codes';
 import nock from 'nock';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -18,7 +17,7 @@ import {
   UNAUTHORIZED_RESPONSE,
   generateFolders,
 } from '../test/constants.js';
-import { mockMutation, setUpTest, waitForMutation } from '../test/utils.js';
+import { mockMutation, setUpTest } from '../test/utils.js';
 
 const mockedNotifier = vi.fn();
 const { wrapper, queryClient, mutations } = setUpTest({
@@ -72,12 +71,9 @@ describe('Publish Item', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
-          id: itemId,
-          notification,
-        });
-        await waitForMutation();
+      await mockedMutation.mutateAsync({
+        id: itemId,
+        notification,
       });
 
       expect(route.includes('notification'));
@@ -136,12 +132,9 @@ describe('Publish Item', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
-          id: itemId,
-          notification: false,
-        });
-        await waitForMutation();
+      await mockedMutation.mutateAsync({
+        id: itemId,
+        notification: false,
       });
 
       expect(
@@ -185,13 +178,12 @@ describe('Publish Item', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
+      await expect(
+        mockedMutation.mutateAsync({
           id: itemId,
           notification,
-        });
-        await waitForMutation();
-      });
+        }),
+      ).rejects.toThrow();
 
       expect(mockedNotifier).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/query/mutations/itemValidation.test.ts
+++ b/src/query/mutations/itemValidation.test.ts
@@ -1,6 +1,5 @@
 import { HttpMethod } from '@graasp/sdk';
 
-import { act } from '@testing-library/react';
 import { StatusCodes } from 'http-status-codes';
 import nock from 'nock';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -12,7 +11,7 @@ import {
   ITEM_VALIDATION_GROUP,
   UNAUTHORIZED_RESPONSE,
 } from '../test/constants.js';
-import { mockMutation, setUpTest, waitForMutation } from '../test/utils.js';
+import { mockMutation, setUpTest } from '../test/utils.js';
 
 const mockedNotifier = vi.fn();
 const { wrapper, queryClient, mutations } = setUpTest({
@@ -49,11 +48,8 @@ describe('Item Validation Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
-          itemId,
-        });
-        await waitForMutation();
+      await mockedMutation.mutateAsync({
+        itemId,
       });
 
       expect(mockedNotifier).toHaveBeenCalledWith({
@@ -76,10 +72,7 @@ describe('Item Validation Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ itemId });
-        await waitForMutation();
-      });
+      await expect(mockedMutation.mutateAsync({ itemId })).rejects.toThrow();
 
       expect(mockedNotifier).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/query/mutations/itemVisibility.test.ts
+++ b/src/query/mutations/itemVisibility.test.ts
@@ -5,7 +5,6 @@ import {
   getIdsFromPath,
 } from '@graasp/sdk';
 
-import { act } from '@testing-library/react';
 import { StatusCodes } from 'http-status-codes';
 import nock from 'nock';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -20,7 +19,7 @@ import {
   postItemVisibilityRoutine,
 } from '../routines/itemVisibility.js';
 import { ITEM_VISIBILITIES, UNAUTHORIZED_RESPONSE } from '../test/constants.js';
-import { mockMutation, setUpTest, waitForMutation } from '../test/utils.js';
+import { mockMutation, setUpTest } from '../test/utils.js';
 
 const mockedNotifier = vi.fn();
 const { wrapper, queryClient, mutations } = setUpTest({
@@ -59,13 +58,10 @@ describe('Item Visibility Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
-          itemId,
-          type: visibilityType,
-          creator,
-        });
-        await waitForMutation();
+      await mockedMutation.mutateAsync({
+        itemId,
+        type: visibilityType,
+        creator,
       });
 
       expect(
@@ -95,14 +91,13 @@ describe('Item Visibility Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({
+      await expect(
+        mockedMutation.mutateAsync({
           itemId,
           type: visibilityType,
           creator,
-        });
-        await waitForMutation();
-      });
+        }),
+      ).rejects.toThrow();
 
       expect(
         queryClient.getQueryState(itemVisibilityKey)?.isInvalidated,
@@ -140,10 +135,7 @@ describe('Item Visibility Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ itemId, type: visibilityType });
-        await waitForMutation();
-      });
+      await mockedMutation.mutateAsync({ itemId, type: visibilityType });
 
       const data = queryClient.getQueryState(itemVisibilityKey);
       expect(data?.isInvalidated).toBeTruthy();
@@ -174,10 +166,9 @@ describe('Item Visibility Mutations', () => {
         wrapper,
       });
 
-      await act(async () => {
-        mockedMutation.mutate({ itemId, type: visibilityType });
-        await waitForMutation();
-      });
+      await expect(
+        mockedMutation.mutateAsync({ itemId, type: visibilityType }),
+      ).rejects.toThrow();
 
       const data = queryClient.getQueryState(itemVisibilityKey);
       expect(data?.isInvalidated).toBeTruthy();

--- a/src/query/mutations/mention.test.ts
+++ b/src/query/mutations/mention.test.ts
@@ -5,7 +5,6 @@ import {
   MentionStatus,
 } from '@graasp/sdk';
 
-import { act } from '@testing-library/react';
 import { StatusCodes } from 'http-status-codes';
 import nock from 'nock';
 import { v4 } from 'uuid';
@@ -30,7 +29,7 @@ import {
   buildMemberMentions,
   buildMentionResponse,
 } from '../test/constants.js';
-import { mockMutation, setUpTest, waitForMutation } from '../test/utils.js';
+import { mockMutation, setUpTest } from '../test/utils.js';
 
 describe('Mention Mutations', () => {
   const mentionId = v4();
@@ -81,12 +80,9 @@ describe('Mention Mutations', () => {
           wrapper,
         });
 
-        await act(async () => {
-          mockedMutation.mutate({
-            id: mentionId,
-            status: MentionStatus.Read,
-          });
-          await waitForMutation();
+        await mockedMutation.mutateAsync({
+          id: mentionId,
+          status: MentionStatus.Read,
         });
 
         // verify cache keys
@@ -115,13 +111,12 @@ describe('Mention Mutations', () => {
           wrapper,
         });
 
-        await act(async () => {
-          mockedMutation.mutate({
+        await expect(
+          mockedMutation.mutateAsync({
             id: mentionId,
             status: MentionStatus.Read,
-          });
-          await waitForMutation();
-        });
+          }),
+        ).rejects.toThrow();
 
         // verify cache keys
         expect(queryClient.getQueryState(key)?.isInvalidated).toBeTruthy();
@@ -158,10 +153,7 @@ describe('Mention Mutations', () => {
           wrapper,
         });
 
-        await act(async () => {
-          mockedMutation.mutate(mentionId);
-          await waitForMutation();
-        });
+        await mockedMutation.mutateAsync(mentionId);
 
         // verify cache keys
         expect(queryClient.getQueryState(key)?.isInvalidated).toBeTruthy();
@@ -189,10 +181,7 @@ describe('Mention Mutations', () => {
           wrapper,
         });
 
-        await act(async () => {
-          mockedMutation.mutate(mentionId);
-          await waitForMutation();
-        });
+        await expect(mockedMutation.mutateAsync(mentionId)).rejects.toThrow();
 
         // verify cache keys
         expect(queryClient.getQueryState(key)?.isInvalidated).toBeTruthy();
@@ -229,10 +218,7 @@ describe('Mention Mutations', () => {
           wrapper,
         });
 
-        await act(async () => {
-          mockedMutation.mutate();
-          await waitForMutation();
-        });
+        await mockedMutation.mutateAsync();
 
         // verify cache keys
         expect(queryClient.getQueryState(key)?.isInvalidated).toBeTruthy();
@@ -256,10 +242,7 @@ describe('Mention Mutations', () => {
           wrapper,
         });
 
-        await act(async () => {
-          mockedMutation.mutate();
-          await waitForMutation();
-        });
+        await expect(mockedMutation.mutateAsync()).rejects.toThrow();
 
         // verify cache keys
         expect(queryClient.getQueryState(key)?.isInvalidated).toBeTruthy();
@@ -307,12 +290,9 @@ describe('Mention Mutations', () => {
           wrapper,
         });
 
-        await act(async () => {
-          mockedMutation.mutate({
-            id: mentionId,
-            status: MentionStatus.Read,
-          });
-          await waitForMutation();
+        await mockedMutation.mutateAsync({
+          id: mentionId,
+          status: MentionStatus.Read,
         });
 
         // verify cache keys
@@ -344,10 +324,7 @@ describe('Mention Mutations', () => {
           wrapper,
         });
 
-        await act(async () => {
-          mockedMutation.mutate(mentionId);
-          await waitForMutation();
-        });
+        await mockedMutation.mutateAsync(mentionId);
 
         // verify cache keys
         expect(queryClient.getQueryState(key)?.isInvalidated).toBeFalsy();
@@ -378,10 +355,7 @@ describe('Mention Mutations', () => {
           wrapper,
         });
 
-        await act(async () => {
-          mockedMutation.mutate();
-          await waitForMutation();
-        });
+        await mockedMutation.mutateAsync();
 
         // verify cache keys
         expect(queryClient.getQueryState(key)?.isInvalidated).toBeFalsy();

--- a/src/query/test/utils.tsx
+++ b/src/query/test/utils.tsx
@@ -168,14 +168,6 @@ export const mockMutation = async <
   return result.current;
 };
 
-// util function to wait some time after a mutation is performed
-// this is necessary for success and error callback to fully execute
-export const waitForMutation = async (t = 500) => {
-  await new Promise((r) => {
-    setTimeout(r, t);
-  });
-};
-
 export const splitEndpointByIds = (
   ids: string[],
   chunkSize: number,


### PR DESCRIPTION
In this PR I try to address the recurrent issue of failing vitest tests. 

The issue seemed to be linked to a dangling `setTimeout` that is called after test teardown. 
This can happen when using `waitForMutation` in case the test terminates before the timeout. 

I simplified the tests by moving all calls from `mockedMutation.mutate()` to `mockedMutation.mutateAsync()` also removing the unnecessary `act()`.
On mutations that throw because of errors (UNAUTHORIZED, file too large etc...) I added an expect toThrow.

Hopefully this fixes the flackyness of the vitest suite.