### PR TITLE
fix: set default state as null for ws

### DIFF
--- a/src/components/page/Editor.tsx
+++ b/src/components/page/Editor.tsx
@@ -59,6 +59,10 @@ export function Editor({ item, currentAccount }: Readonly<Props>) {
   };
 
   const initialConfig: InitialConfigType = {
+    // NOTE: This is critical for collaboration plugin to set editor state to null. It
+    // would indicate that the editor should not try to set any default state
+    // (not even empty one), and let collaboration plugin do it instead
+    editorState: null,
     namespace: 'MyEditor',
     theme,
     onError,


### PR DESCRIPTION
This addition fixes the problem of syncinc on init (first messages not being sent at the beginning).

It probably resulted in an non-stable state, until adding a block (enter a paragraph, not just text, or adding a link block).
This non-stable state would exist as long as no data existed (on creation, not submitting paragraphs)