### PR TITLE
fix: cypress error due to change in @tanstack/router

### DIFF
--- a/src/routes/auth/reset-password.tsx
+++ b/src/routes/auth/reset-password.tsx
@@ -48,6 +48,7 @@ const resetPasswordSchema = z.object({
 export const Route = createFileRoute('/auth/reset-password')({
   validateSearch: zodValidator(resetPasswordSchema),
   component: ResetPassword,
+  errorComponent: InvalidTokenScreen,
 });
 
 type Inputs = {


### PR DESCRIPTION
This fixes an error that was introduced when updating @tanstack/router in #1104 

I decided to ignore this error in the aforementioned PR and merged anyway. This PR fixes the issue by providing an error component. 

The behaviour has changed on tanstack router when we provide a token that has an invalid value (in the cas of the failing test, a number) when it is expecting a string. 

Providing the errorComponent to the route re-establishes the expected behviour.