### PR TITLE
fix: fix link related bugs

### DIFF
--- a/src/components/page/Editor.tsx
+++ b/src/components/page/Editor.tsx
@@ -71,7 +71,7 @@ export function Editor({ item, currentAccount }: Readonly<Props>) {
   };
 
   return (
-    <div ref={containerRef}>
+    <div ref={containerRef} style={{ marginBottom: '16px' }}>
       <StatusToolbar users={activeUsers} isConnected={connected} />
       {hasTimedOut && (
         <Alert
@@ -95,7 +95,12 @@ export function Editor({ item, currentAccount }: Readonly<Props>) {
         <>
           <LexicalComposer initialConfig={initialConfig}>
             <div
-              style={{ width: '100%', height: '100vh', background: 'white' }}
+              style={{
+                width: '100%',
+                height: '100%',
+                border: '1px solid #dddddd',
+                borderRadius: '8px',
+              }}
             >
               <ToolbarPlugin />
               <div className="editor-inner">

--- a/src/components/page/NodeMenu.tsx
+++ b/src/components/page/NodeMenu.tsx
@@ -29,7 +29,7 @@ export function NodeMenu({
           <Stack
             sx={{
               position: 'absolute',
-              zIndex: 9,
+              zIndex: 1,
               top: -50,
               boxShadow: '0 4px 8px lightgrey',
               background: 'white',

--- a/src/components/page/plugins/DebugPlugin.tsx
+++ b/src/components/page/plugins/DebugPlugin.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+
+function DebugPlugin() {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    editor.registerUpdateListener(({ editorState }) => {
+      // The latest EditorState can be found as `editorState`.
+      // To read the contents of the EditorState, use the following API:
+
+      console.debug(editorState);
+
+      editorState.read(() => {
+        // Just like editor.update(), .read() expects a closure where you can use
+        // the $ prefixed helper functions.
+      });
+    });
+  });
+
+  return null;
+}
+
+export default DebugPlugin;

--- a/src/components/page/plugins/FontSize.tsx
+++ b/src/components/page/plugins/FontSize.tsx
@@ -103,6 +103,10 @@ export function FontSize({
           width: 30,
           height: 30,
           boxSizing: 'border-box',
+          // disable arrows in input type number
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-expect-error
+          '-moz-appearance': 'textfield',
         }}
         className="font-size-input"
         min={MIN_ALLOWED_FONT_SIZE}

--- a/src/components/page/plugins/linkItem/LinkItemForPage.tsx
+++ b/src/components/page/plugins/linkItem/LinkItemForPage.tsx
@@ -1,4 +1,4 @@
-import { JSX, useEffect, useState } from 'react';
+import { JSX, memo, useEffect, useState } from 'react';
 
 import { Alert, Box, Link as MUILink, Skeleton } from '@mui/material';
 
@@ -33,6 +33,7 @@ function LinkItem({
   errorMessage,
   nodeKey,
   memberId,
+  setSelected,
 }: {
   url: string;
   layout: Layout;
@@ -42,6 +43,7 @@ function LinkItem({
   errorMessage?: string;
   nodeKey: NodeKey;
   memberId?: string;
+  setSelected?: (selected: boolean) => void;
 }) {
   const { data: linkMetadata, isFetching } = useQuery(
     getLinkMetadataOptions({ query: { link: url } }),
@@ -83,17 +85,36 @@ function LinkItem({
     }
 
     return (
-      <LinkIframe
-        url={url}
-        isResizable={isResizable}
-        height={height}
-        title={linkMetadata?.title ?? url}
-        isLoading={isLoading}
-        onDoneLoading={() => setIsLoading(false)}
-        itemId={nodeKey}
-        memberId={memberId}
-        loadingMessage={loadingMessage}
-      />
+      <Box
+        onClick={(e) => {
+          e.stopPropagation();
+          setSelected?.(true);
+        }}
+        sx={{ position: 'relative' }}
+      >
+        <Box
+          sx={{
+            height,
+            width: '100%',
+            position: 'absolute',
+            zIndex: 1,
+          }}
+        ></Box>
+        <LinkIframe
+          url={url}
+          isResizable={isResizable}
+          height={height}
+          title={linkMetadata?.title ?? url}
+          isLoading={isLoading}
+          onDoneLoading={() => {
+            setIsLoading(false);
+          }}
+          id="theiframe"
+          itemId={nodeKey}
+          memberId={memberId}
+          loadingMessage={loadingMessage}
+        />
+      </Box>
     );
   }
 
@@ -103,9 +124,13 @@ function LinkItem({
       <LinkCard
         thumbnail={linkMetadata?.icons?.[0]}
         title={linkMetadata?.title ?? url}
-        url={url}
+        urlText={url}
         description=""
         isExternal={isExternal}
+        onClick={(e) => {
+          e.stopPropagation();
+          setSelected?.(true);
+        }}
       />
     );
   }
@@ -139,6 +164,7 @@ type LinkItemComponentProps = Readonly<{
   isResizable?: boolean;
   height?: string | number;
   canEdit?: boolean;
+  setSelected?: (selected: boolean) => void;
 }>;
 
 export function LinkItemComponent({
@@ -154,6 +180,7 @@ export function LinkItemComponent({
   errorMessage = 'The link is malformed.',
   onLayoutChange,
   onUrlChange,
+  setSelected,
 }: LinkItemComponentProps) {
   const [height] = useState<string | number>(defaultHeight);
   const [isSelected] = useLexicalNodeSelection(nodeKey);
@@ -176,6 +203,7 @@ export function LinkItemComponent({
         nodeKey={nodeKey}
       >
         <LinkItem
+          setSelected={setSelected}
           url={url}
           layout={layout}
           isResizable
@@ -189,3 +217,5 @@ export function LinkItemComponent({
     </>
   );
 }
+
+export const LinkItemForPage = memo(LinkItemComponent);

--- a/src/components/page/plugins/linkItem/LinkItemNode.tsx
+++ b/src/components/page/plugins/linkItem/LinkItemNode.tsx
@@ -12,6 +12,8 @@ import {
   SerializedDecoratorBlockNode,
 } from '@lexical/react/LexicalDecoratorBlockNode';
 import {
+  $createNodeSelection,
+  $setSelection,
   DOMConversionMap,
   DOMConversionOutput,
   type DOMExportOutput,
@@ -23,7 +25,7 @@ import {
   type Spread,
 } from 'lexical';
 
-import { LinkItemComponent } from './LinkItemComponent';
+import { LinkItemForPage } from './LinkItemForPage';
 
 export type SerializedLinkItemNode = Spread<
   {
@@ -142,6 +144,14 @@ export class LinkItemNode extends DecoratorBlockNode {
     };
   }
 
+  select(editor: LexicalEditor) {
+    editor.update(() => {
+      const nodeSelection = $createNodeSelection();
+      nodeSelection.add(this.getKey());
+      $setSelection(nodeSelection);
+    });
+  }
+
   decorate(editor: LexicalEditor, config: EditorConfig): JSX.Element {
     const embedBlockTheme = config.theme.embedBlock || {};
     const className = {
@@ -152,7 +162,7 @@ export class LinkItemNode extends DecoratorBlockNode {
     const isEditable = editor.isEditable();
 
     return (
-      <LinkItemComponent
+      <LinkItemForPage
         className={className}
         format={this.__format}
         nodeKey={this.getKey()}
@@ -162,6 +172,9 @@ export class LinkItemNode extends DecoratorBlockNode {
         onUrlChange={this.changeUrl(editor)}
         canEdit={isEditable}
         isResizable={isEditable}
+        setSelected={() => {
+          this.select(editor);
+        }}
       />
     );
   }

--- a/src/components/page/plugins/linkItem/menu/useLinkItemMenuUrl.tsx
+++ b/src/components/page/plugins/linkItem/menu/useLinkItemMenuUrl.tsx
@@ -10,6 +10,8 @@ import {
   DialogContent,
 } from '@mui/material';
 
+import { SquareArrowOutUpRightIcon } from 'lucide-react';
+
 import { NS } from '@/config/constants';
 
 import LinkUrlField from '~builder/components/item/form/link/LinkUrlField';
@@ -68,7 +70,17 @@ export function useLinkItemMenuUrl({ url, onUrlChange }: LinkItemMenuUrlProps) {
           <Box component="form" onSubmit={handleSubmit(onSubmit)}>
             <DialogContent>
               <LinkUrlField />
+              <Button
+                component="a"
+                href={url}
+                target="_blank"
+                rel="noreferrer"
+                endIcon={<SquareArrowOutUpRightIcon size={16} />}
+              >
+                {t('Visit external link')}
+              </Button>
             </DialogContent>
+
             <DialogActions>
               <Button size="small" onClick={handleClose}>
                 {translateCommon('CANCEL.BUTTON_TEXT')}

--- a/src/components/page/styles.css
+++ b/src/components/page/styles.css
@@ -84,9 +84,10 @@
   overflow: auto;
   height: 36px;
   position: sticky;
-  top: 0;
-  /* remove zindex to avoid overlapping with item menus */
   overflow-y: hidden; /* disable vertical scroll*/
+  top: 65px; /* this value depends on the header height */
+  z-index: 5; /* unless zindex is removed, item menus will be under */
+  border-bottom: 1px solid #ddd;
 }
 
 button.toolbar-item {

--- a/src/ui/Card/LinkCard.tsx
+++ b/src/ui/Card/LinkCard.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react';
+import type { JSX, MouseEventHandler } from 'react';
 
 import {
   Card,
@@ -20,11 +20,12 @@ const FANCY_LINK_CARD_TEST_ID = 'fancy-link-card';
 type FancyLinkProps = {
   id?: string;
   title: string;
-  url: string;
+  url?: string;
+  urlText?: string;
   thumbnail?: string;
   description: string;
   isExternal?: boolean;
-  onClick?: () => void;
+  onClick?: MouseEventHandler;
 };
 
 const FancyLink = ({
@@ -33,6 +34,7 @@ const FancyLink = ({
   thumbnail,
   description,
   url,
+  urlText,
   onClick,
   isExternal = true,
 }: FancyLinkProps): JSX.Element => {
@@ -50,7 +52,11 @@ const FancyLink = ({
       }}
       data-testid={FANCY_LINK_CARD_TEST_ID}
     >
-      <CardActionArea href={url} sx={{ height: '100%' }} onClick={onClick}>
+      <CardActionArea
+        href={url ?? ''}
+        sx={{ height: '100%' }}
+        onClick={onClick}
+      >
         <Stack direction="row" alignItems="center" height="100%" minWidth={0}>
           <CardThumbnail
             thumbnail={thumbnail}
@@ -88,7 +94,7 @@ const FancyLink = ({
                 </Stack>
                 {isExternal && (
                   <Typography color="text.secondary" noWrap variant="caption">
-                    ({url})
+                    ({urlText ?? url})
                   </Typography>
                 )}
               </Stack>


### PR DESCRIPTION
- Toolbar is sticky
- Remove white background for editor, to match with player view 
- Allow click on link (prevent redirection) to select the node and show the options. It is possible to visit the url through the link menu.
- Hide firefox input number's arrow (font size)