### PR TITLE
feat: improve landing menu responsiveness

### DIFF
--- a/src/components/ui/ButtonLink.tsx
+++ b/src/components/ui/ButtonLink.tsx
@@ -2,7 +2,12 @@ import { forwardRef } from 'react';
 
 import { Button, ButtonProps } from '@mui/material';
 
-import { LinkComponent, createLink } from '@tanstack/react-router';
+import {
+  LinkComponent,
+  UseLinkPropsOptions,
+  createLink,
+  useLinkProps,
+} from '@tanstack/react-router';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface MUIButtonProps extends Omit<ButtonProps, 'href'> {
@@ -11,12 +16,23 @@ interface MUIButtonProps extends Omit<ButtonProps, 'href'> {
 
 const MUILinkComponent = forwardRef<HTMLAnchorElement, MUIButtonProps>(
   (props, ref) => {
+    const linkProps = useLinkProps(props as UseLinkPropsOptions);
+
+    // obtain fontweight, usually from activeProps
+    const fw =
+      'fontWeight' in linkProps ? (linkProps.fontWeight as string) : 'inherit';
+
     return (
       <Button
         component={'a'}
         ref={ref}
         {...props}
-        sx={{ textTransform: 'none', minWidth: 'unset', ...props.sx }}
+        sx={{
+          textTransform: 'none',
+          minWidth: 'unset',
+          fontWeight: fw,
+          ...props.sx,
+        }}
       />
     );
   },

--- a/src/components/ui/HeaderRightContent.tsx
+++ b/src/components/ui/HeaderRightContent.tsx
@@ -47,7 +47,7 @@ export function HeaderRightContent() {
 
   if (isAuthenticated) {
     return (
-      <Stack direction="row" gap={2} alignItems="center">
+      <Stack direction="row" gap={1} alignItems="center">
         {
           // only display these elements to "full users"
           user.type === AccountType.Individual && (
@@ -58,6 +58,7 @@ export function HeaderRightContent() {
                 id="languageSwitch"
                 lang={i18n.languages[0]}
                 onChange={handleLanguageChange}
+                color="white"
               />
             </>
           )

--- a/src/components/ui/LanguageSwitch.tsx
+++ b/src/components/ui/LanguageSwitch.tsx
@@ -1,50 +1,111 @@
-import type { JSX } from 'react';
+import { type JSX, type MouseEvent, useState } from 'react';
 
-import {
-  MenuItem,
-  Select as MuiSelect,
-  SelectChangeEvent,
-} from '@mui/material';
+import { IconButton, MenuItem } from '@mui/material';
+import Button from '@mui/material/Button';
+import Menu from '@mui/material/Menu';
+
+import { ChevronDown, LanguagesIcon } from 'lucide-react';
 
 import { LANGS } from '@/config/langs';
 
 type Props = {
   id?: string;
   lang: string;
+  dense?: boolean;
+  color?: string;
   onChange: (newLang: string) => void;
 };
 
-const LanguageSwitch = ({ id, lang, onChange }: Props): JSX.Element => {
-  const handleChange = (event: SelectChangeEvent<unknown>) => {
-    const newLang = event.target.value as string;
-    if (newLang) {
-      onChange(newLang);
-    } else {
-      console.error('The lang is not valid');
-    }
+const values = Object.entries(LANGS).map(([value, text]) => ({
+  value,
+  text,
+}));
+
+const LanguageSwitch = ({
+  id,
+  lang,
+  onChange,
+  color,
+  dense = true,
+}: Props): JSX.Element => {
+  const handleChange = (newLang: string) => {
+    onChange(newLang);
+    setAnchorEl(null);
   };
 
-  const values = Object.entries(LANGS).map(([value, text]) => ({
-    value,
-    text,
-  }));
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
-  return (
-    <MuiSelect
-      id={id}
-      onChange={handleChange}
-      renderValue={(v) => v.toUpperCase()}
-      variant="outlined"
-      value={lang}
-      size="small"
-      sx={{ backgroundColor: 'rgb(255,255,255,45%)' }}
+  const menu = (
+    <Menu
+      id="basic-menu"
+      anchorEl={anchorEl}
+      open={open}
+      onClose={handleClose}
+      slotProps={{
+        list: {
+          'aria-labelledby': 'basic-button',
+        },
+      }}
     >
       {values.map(({ value, text }) => (
-        <MenuItem key={value} id={value} value={value}>
+        <MenuItem
+          key={value}
+          id={value}
+          value={value}
+          onClick={() => handleChange(value)}
+          selected={value === lang}
+        >
           {text}
         </MenuItem>
       ))}
-    </MuiSelect>
+    </Menu>
+  );
+
+  if (dense) {
+    return (
+      <div id={id}>
+        <IconButton
+          id="basic-button"
+          aria-controls={open ? 'basic-menu' : undefined}
+          aria-haspopup="true"
+          aria-expanded={open ? 'true' : undefined}
+          onClick={handleClick}
+          sx={{ fontWeight: 'bold', color }}
+        >
+          <LanguagesIcon />
+        </IconButton>
+        {menu}
+      </div>
+    );
+  }
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
+  const language = lang in LANGS ? LANGS[lang] : LANGS.en;
+
+  return (
+    <div id={id}>
+      <Button
+        id="basic-button"
+        aria-controls={open ? 'basic-menu' : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        onClick={handleClick}
+        startIcon={<LanguagesIcon />}
+        endIcon={<ChevronDown size={15} />}
+        sx={{ fontWeight: 'bold', color }}
+      >
+        {language}
+      </Button>
+      {menu}
+    </div>
   );
 };
 

--- a/src/components/ui/MenuItemLink.tsx
+++ b/src/components/ui/MenuItemLink.tsx
@@ -2,7 +2,12 @@ import { forwardRef } from 'react';
 
 import { MenuItem, MenuItemProps } from '@mui/material';
 
-import { LinkComponent, createLink } from '@tanstack/react-router';
+import {
+  LinkComponent,
+  UseLinkPropsOptions,
+  createLink,
+  useLinkProps,
+} from '@tanstack/react-router';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface MUIMenuItemProps extends Omit<MenuItemProps, 'href'> {
@@ -11,7 +16,15 @@ interface MUIMenuItemProps extends Omit<MenuItemProps, 'href'> {
 
 const MUIMenuItemComponent = forwardRef<HTMLAnchorElement, MUIMenuItemProps>(
   (props, ref) => {
-    return <MenuItem component={'a'} ref={ref} {...props} />;
+    const linkProps = useLinkProps(props as UseLinkPropsOptions);
+
+    // obtain fontweight, usually from activeProps
+    const selected =
+      'selected' in linkProps ? Boolean(linkProps.selected) : false;
+
+    return (
+      <MenuItem component={'a'} ref={ref} selected={selected} {...props} />
+    );
   },
 );
 

--- a/src/locales/en/landing.json
+++ b/src/locales/en/landing.json
@@ -1,5 +1,6 @@
 {
   "NAVBAR": {
+    "HOME":"Home",
     "GETTING_STARTED": "Getting started",
     "FEATURES": "Features",
     "LIBRARY": "Library",

--- a/src/modules/landing/footer/Footer.tsx
+++ b/src/modules/landing/footer/Footer.tsx
@@ -184,7 +184,12 @@ export function Footer({ onChangeLang }: Readonly<FooterProps>): JSX.Element {
                 {t('OTHER.DISCLAIMER')}
               </InternalLink>
               <Box>
-                <LanguageSwitch lang={i18n.language} onChange={onChangeLang} />
+                <LanguageSwitch
+                  dense={false}
+                  lang={i18n.language}
+                  onChange={onChangeLang}
+                  color="white"
+                />
               </Box>
             </FooterSection>
           </Stack>

--- a/src/modules/landing/header/Menu.tsx
+++ b/src/modules/landing/header/Menu.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from 'react-i18next';
+
+import { Stack } from '@mui/material';
+
+import { ButtonLink } from '@/components/ui/ButtonLink';
+import { NS } from '@/config/constants';
+import { GRAASP_LIBRARY_HOST } from '@/config/env';
+
+export function Menu() {
+  const { t } = useTranslation(NS.Landing, { keyPrefix: 'NAVBAR' });
+  return (
+    <Stack direction="row" gap={2}>
+      <ButtonLink activeProps={() => ({ fontWeight: 'bold' })} to="/features">
+        {t('FEATURES')}
+      </ButtonLink>
+      <ButtonLink activeProps={() => ({ fontWeight: 'bold' })} to="/support">
+        {t('GETTING_STARTED')}
+      </ButtonLink>
+      <ButtonLink
+        activeProps={() => ({ fontWeight: 'bold' })}
+        to={GRAASP_LIBRARY_HOST}
+      >
+        {t('LIBRARY')}
+      </ButtonLink>
+      <ButtonLink activeProps={() => ({ fontWeight: 'bold' })} to="/about-us">
+        {t('ABOUT_US')}
+      </ButtonLink>
+    </Stack>
+  );
+}

--- a/src/modules/landing/header/MobileMenu.tsx
+++ b/src/modules/landing/header/MobileMenu.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { IconButton } from '@mui/material';
+import Menu from '@mui/material/Menu';
+
+import { MenuIcon } from 'lucide-react';
+
+import { MenuItemLink } from '@/components/ui/MenuItemLink';
+import { NS } from '@/config/constants';
+import { GRAASP_LIBRARY_HOST } from '@/config/env';
+
+export default function MobileMenu() {
+  const { t } = useTranslation(NS.Landing, { keyPrefix: 'NAVBAR' });
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <div>
+      <IconButton
+        id="landing-mobile-menu"
+        aria-controls={open ? 'demo-positioned-menu' : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        onClick={handleClick}
+        sx={{ border: '1px solid' }}
+      >
+        <MenuIcon />
+      </IconButton>
+      <Menu
+        aria-labelledby="landing-mobile-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+      >
+        <MenuItemLink
+          activeProps={() => ({ selected: true })}
+          to="/"
+          onClick={handleClose}
+        >
+          {t('HOME')}
+        </MenuItemLink>
+        <MenuItemLink
+          activeProps={() => ({ selected: true })}
+          to="/features"
+          onClick={handleClose}
+        >
+          {t('FEATURES')}
+        </MenuItemLink>
+        <MenuItemLink
+          activeProps={() => ({ selected: true })}
+          to="/support"
+          onClick={handleClose}
+        >
+          {t('GETTING_STARTED')}
+        </MenuItemLink>
+        <MenuItemLink
+          activeProps={() => ({ selected: true })}
+          to={GRAASP_LIBRARY_HOST}
+          onClick={handleClose}
+        >
+          {t('LIBRARY')}
+        </MenuItemLink>
+        <MenuItemLink
+          activeProps={() => ({ selected: true })}
+          to="/about-us"
+          onClick={handleClose}
+        >
+          {t('ABOUT_US')}
+        </MenuItemLink>
+      </Menu>
+    </div>
+  );
+}

--- a/src/modules/landing/header/NavBar.tsx
+++ b/src/modules/landing/header/NavBar.tsx
@@ -1,0 +1,117 @@
+import { useTranslation } from 'react-i18next';
+import { toast } from 'react-toastify';
+
+import { Stack, Typography, useMediaQuery, useTheme } from '@mui/material';
+
+import { AccountType } from '@graasp/sdk';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+
+import { useAuth } from '@/AuthContext';
+import { NS } from '@/config/constants';
+import { LANDING_PAGE_PATH } from '@/config/paths';
+import { updateCurrentAccountMutation } from '@/openapi/client/@tanstack/react-query.gen';
+import { memberKeys } from '@/query/keys';
+import { OnChangeLangProp } from '@/types';
+import GraaspLogo from '@/ui/GraaspLogo/GraaspLogo';
+import { useButtonColor } from '@/ui/buttons/hooks';
+import { useMobileView } from '@/ui/hooks/useMobileView';
+
+import { Menu } from '~landing/header/Menu';
+import MobileMenu from '~landing/header/MobileMenu';
+import { RightHeader } from '~landing/header/RightHeader';
+import { usePreviewMode } from '~landing/preview/PreviewModeContext';
+
+export function NavBar() {
+  const { i18n } = useTranslation(NS.Landing, { keyPrefix: 'NAVBAR' });
+  const { t: translateMessage } = useTranslation(NS.Messages);
+  const { isAuthenticated, user } = useAuth();
+  const { isMobile } = useMobileView();
+  const { fill: primary } = useButtonColor('primary');
+
+  const theme = useTheme();
+  const showFullLengthMenu = useMediaQuery(theme.breakpoints.up('lg'));
+
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation({
+    ...updateCurrentAccountMutation(),
+    onError: (error: Error) => {
+      console.error(error);
+      toast.error(translateMessage('EDIT_MEMBER_ERROR'));
+    },
+    // Always refetch after error or success:
+    onSettled: async () => {
+      // invalidate all queries
+      await queryClient.invalidateQueries({
+        queryKey: memberKeys.current().content,
+      });
+    },
+  });
+  const { isEnabled: isPreviewEnabled } = usePreviewMode();
+  const onChangeLang: OnChangeLangProp = (lang: string) => {
+    // only "full users" can change their language
+    if (isAuthenticated && user.type === AccountType.Individual) {
+      mutate({ body: { extra: { lang } } });
+    }
+    i18n.changeLanguage(lang);
+  };
+
+  return (
+    <Stack
+      // take maximum width
+      width="100%"
+      // make some room around the buttons
+      p={2}
+      gap={2}
+      bgcolor="white"
+      position="fixed"
+      top="0px"
+      sx={{
+        boxShadow: (t) => t.shadows[3],
+        zIndex: (t) => t.zIndex.appBar,
+      }}
+    >
+      <Stack
+        direction="row"
+        maxWidth="lg"
+        // take maximum width
+        width="100%"
+        m="auto"
+        // separate the logo part from the buttons part
+        justifyContent="space-between"
+      >
+        <Stack
+          direction="row"
+          alignItems="center"
+          id="rightTitleWrapper"
+          gap={4}
+        >
+          <Stack direction="row" gap={1} alignItems="center">
+            {!showFullLengthMenu && <MobileMenu />}
+            <Stack
+              to={LANDING_PAGE_PATH}
+              component={Link}
+              // override link styling
+              sx={{ textDecoration: 'none', color: 'inherit' }}
+            >
+              <GraaspLogo height={44} sx={{ fill: primary! }} />
+            </Stack>
+            {!isMobile && (
+              <Typography fontWeight="bold" variant="h2" color="primary">
+                Graasp
+                {isPreviewEnabled ? (
+                  <Typography variant="note">preview</Typography>
+                ) : (
+                  ''
+                )}
+              </Typography>
+            )}
+          </Stack>
+          {showFullLengthMenu && <Menu />}
+        </Stack>
+        <RightHeader onChangeLang={onChangeLang} />
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/modules/landing/header/RightHeader.tsx
+++ b/src/modules/landing/header/RightHeader.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Stack } from '@mui/material';
+import { Stack, useMediaQuery, useTheme } from '@mui/material';
 
 import { AccountType } from '@graasp/sdk';
 
@@ -23,6 +23,9 @@ export function RightHeader({
   const { isAuthenticated, user } = useAuth();
   const { t, i18n } = useTranslation(NS.Common);
   const { t: translateLanding } = useTranslation(NS.Landing);
+
+  const theme = useTheme();
+  const showRegisterButton = useMediaQuery(theme.breakpoints.up('sm'));
 
   if (isAuthenticated) {
     if (user.type === AccountType.Individual) {
@@ -63,7 +66,9 @@ export function RightHeader({
   return (
     <Stack gap={2} direction="row" id="leftTitleWrapper" alignItems="center">
       <ButtonLink to="/auth/login">{t('LOG_IN.BUTTON_TEXT')}</ButtonLink>
-      <ButtonLink to="/auth/register">{t('REGISTER.BUTTON_TEXT')}</ButtonLink>
+      {showRegisterButton && (
+        <ButtonLink to="/auth/register">{t('REGISTER.BUTTON_TEXT')}</ButtonLink>
+      )}
       <LanguageSwitch lang={i18n.language} onChange={onChangeLang} />
     </Stack>
   );

--- a/src/routes/_landing.tsx
+++ b/src/routes/_landing.tsx
@@ -1,40 +1,31 @@
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
 
-import { Stack, Typography } from '@mui/material';
+import { Stack } from '@mui/material';
 
 import { AccountType } from '@graasp/sdk';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Link, Outlet, createFileRoute } from '@tanstack/react-router';
+import { Outlet, createFileRoute } from '@tanstack/react-router';
 
 import { useAuth } from '@/AuthContext';
-import { ButtonLink } from '@/components/ui/ButtonLink';
 import { NS } from '@/config/constants';
-import { GRAASP_LIBRARY_HOST } from '@/config/env';
-import { LANDING_PAGE_PATH } from '@/config/paths';
 import { updateCurrentAccountMutation } from '@/openapi/client/@tanstack/react-query.gen';
 import { memberKeys } from '@/query/keys';
 import { OnChangeLangProp } from '@/types';
-import GraaspLogo from '@/ui/GraaspLogo/GraaspLogo';
-import { useButtonColor } from '@/ui/buttons/hooks';
-import { useMobileView } from '@/ui/hooks/useMobileView';
 import { DEFAULT_BACKGROUND_COLOR } from '@/ui/theme';
 
 import { Footer } from '~landing/footer/Footer';
-import { RightHeader } from '~landing/header/RightHeader';
-import { usePreviewMode } from '~landing/preview/PreviewModeContext';
+import { NavBar } from '~landing/header/NavBar';
 
 export const Route = createFileRoute('/_landing')({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const { i18n, t } = useTranslation(NS.Landing, { keyPrefix: 'NAVBAR' });
+  const { i18n } = useTranslation(NS.Landing, { keyPrefix: 'NAVBAR' });
   const { t: translateMessage } = useTranslation(NS.Messages);
   const { isAuthenticated, user } = useAuth();
-  const { isMobile } = useMobileView();
-  const { fill: primary } = useButtonColor('primary');
 
   const queryClient = useQueryClient();
   const { mutate } = useMutation({
@@ -51,7 +42,6 @@ function RouteComponent() {
       });
     },
   });
-  const { isEnabled: isPreviewEnabled } = usePreviewMode();
   const onChangeLang: OnChangeLangProp = (lang: string) => {
     // only "full users" can change their language
     if (isAuthenticated && user.type === AccountType.Individual) {
@@ -62,91 +52,7 @@ function RouteComponent() {
 
   return (
     <Stack alignItems="center" minHeight="100svh">
-      <Stack
-        // take maximum width
-        width="100%"
-        // make some room around the buttons
-        p={2}
-        gap={2}
-        bgcolor="white"
-        position="fixed"
-        top="0px"
-        sx={{
-          boxShadow: (theme) => theme.shadows[3],
-          zIndex: (theme) => theme.zIndex.appBar,
-        }}
-      >
-        <Stack
-          direction="row"
-          maxWidth="lg"
-          // take maximum width
-          width="100%"
-          m="auto"
-          // separate the logo part from the buttons part
-          justifyContent="space-between"
-        >
-          <Stack
-            direction="row"
-            alignItems="center"
-            id="rightTitleWrapper"
-            gap={4}
-          >
-            <Stack
-              direction="row"
-              gap={1}
-              alignItems="center"
-              component={Link}
-              to={LANDING_PAGE_PATH}
-              // override link styling
-              sx={{ textDecoration: 'none', color: 'inherit' }}
-            >
-              <GraaspLogo height={44} sx={{ fill: primary! }} />
-              {!isMobile && (
-                <Typography fontWeight="bold" variant="h2" color="primary">
-                  Graasp
-                  {isPreviewEnabled ? (
-                    <Typography variant="note">preview</Typography>
-                  ) : (
-                    ''
-                  )}
-                </Typography>
-              )}
-            </Stack>
-            <Stack
-              direction="row"
-              display={{ xs: 'none', sm: 'unset' }}
-              gap={2}
-              alignItems="center"
-            >
-              <ButtonLink
-                activeProps={() => ({ fontStyle: 'bold' })}
-                to="/features"
-              >
-                {t('FEATURES')}
-              </ButtonLink>
-              <ButtonLink
-                activeProps={() => ({ fontStyle: 'bold' })}
-                to="/support"
-              >
-                {t('GETTING_STARTED')}
-              </ButtonLink>
-              <ButtonLink
-                activeProps={() => ({ fontStyle: 'bold' })}
-                to={GRAASP_LIBRARY_HOST}
-              >
-                {t('LIBRARY')}
-              </ButtonLink>
-              <ButtonLink
-                activeProps={() => ({ fontStyle: 'bold' })}
-                to="/about-us"
-              >
-                {t('ABOUT_US')}
-              </ButtonLink>
-            </Stack>
-          </Stack>
-          <RightHeader onChangeLang={onChangeLang} />
-        </Stack>
-      </Stack>
+      <NavBar />
       <Stack
         id="bodyWrapper"
         direction="column"

--- a/src/routes/_landing/index.tsx
+++ b/src/routes/_landing/index.tsx
@@ -9,7 +9,7 @@ import { NewsLetter } from '~landing/home/NewsLetter';
 import { OurMissionSection } from '~landing/home/OurMissionSection';
 import { TitleSection } from '~landing/home/TitleSection';
 import { UserStorySection } from '~landing/home/UserStorySection';
-import { UserTestimoniesSection } from '~landing/home/UserTestimoniesSection';
+// import { UserTestimoniesSection } from '~landing/home/UserTestimoniesSection';
 import { Preview } from '~landing/preview/PreviewModeContext';
 
 export const Route = createFileRoute('/_landing/')({
@@ -26,9 +26,9 @@ function Index() {
       <PlatformCube />
       <UserStorySection />
       <OurMissionSection />
-      <Preview>
+      {/* <Preview>
         <UserTestimoniesSection />
-      </Preview>
+      </Preview> */}
       <Preview>
         <NewsLetter />
       </Preview>


### PR DESCRIPTION
Show a burger menu when the screen is too small. Actually the screen is too small already at `lg`, because we have 2 menus. I prioritized the action buttons on the right. 

On xs and logged out, the register button is hidden and only the login button is displayed.

https://github.com/user-attachments/assets/29a40cc1-7e9d-4549-a370-db8c4d2009de



close #1084

This PR is based on https://github.com/graasp/client/pull/1119