### PR TITLE
fix: add login error message and dev mailbox

### DIFF
--- a/src/modules/auth/components/common/ErrorDisplay.tsx
+++ b/src/modules/auth/components/common/ErrorDisplay.tsx
@@ -13,14 +13,13 @@ export function ErrorDisplay({
   error: Error | null;
 }>): JSX.Element | null {
   const { t } = useTranslation(NS.Messages);
-
   if (!error) {
     return null;
   }
 
   return (
     <Alert id={ERROR_DISPLAY_ID} severity="error">
-      {t(getErrorMessageFromPayload({ error }))}
+      {t(getErrorMessageFromPayload(error))}
     </Alert>
   );
 }

--- a/src/routes/auth/success.tsx
+++ b/src/routes/auth/success.tsx
@@ -1,7 +1,14 @@
 import { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { Box, Button, Stack, Typography } from '@mui/material';
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  Stack,
+  Typography,
+} from '@mui/material';
 
 import { RecaptchaAction } from '@graasp/sdk';
 
@@ -74,6 +81,15 @@ function RouteComponent() {
             <MailIcon size={30} />
             {t('SIGN_IN_SUCCESS_TITLE')}
           </Typography>
+          {import.meta.env.DEV && (
+            <Alert severity="info">
+              <AlertTitle>Development Mailbox</AlertTitle>
+              <Typography variant="body1">
+                You are running in development mode. The emails are caught by{' '}
+                <a href="http://localhost:1080">the development mailbox</a>.
+              </Typography>
+            </Alert>
+          )}
           <Typography variant="body1" align="justify">
             <Trans
               ns={NS.Auth}


### PR DESCRIPTION
In this PR:

- improve error message when user is not a member yet
- add a link to the dev mailbox when running in dev to improve flow