### PR TITLE
fix: update cloudfront invalidation to include language files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
         shell: bash
         run: |
           distribution_id=$(aws cloudfront list-distributions --query "DistributionList.Items[?Comment=='client'].Id" --output text)
-          aws cloudfront create-invalidation --distribution-id $distribution_id --paths '/index.html' '/locales/*'
+          aws cloudfront create-invalidation --distribution-id $distribution_id --paths '/index.html' '/locales*'
 
       - name: Create Sentry release
         uses: getsentry/action-release@v1


### PR DESCRIPTION
In this PR I update the invalidation paths that are used after a deployment.

We should include the `/locales*` in the invalidation so updates to the translations are propagated to clients.