### PR TITLE
fix: add better auth error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "build": "tsc -b && vite build",
     "build:dev": "tsc -b && vite build --mode development",
     "build:test": "tsc -b && vite build --mode test",
+    "build-prod": "VITE_BASE_URL=/client pnpm build",
     "preview": "vite preview",
     "preview:dev": "vite preview --mode development",
     "preview:test": "vite preview --mode test",

--- a/src/locales/en/auth.json
+++ b/src/locales/en/auth.json
@@ -86,5 +86,13 @@
   "INVALID_TOKEN_PROVIDED_DESCRIPTION": "No token was provided or the provided token is expired. Click the button below to generate a request to reset your password.",
   "REDIRECTION_TITLE": "Welcome back, {{name}}",
   "REDIRECTION_DESCRIPTION": "You are logged in.",
-  "REDIRECTION_BUTTON": "Go to Graasp"
+  "REDIRECTION_BUTTON": "Go to Graasp",
+  "WELCOME": "Welcome to Graasp",
+  "WELCOME_MESSAGE": "To start using Graasp, please log in or register.",
+  "I_HAVE_AN_ACCOUNT": "I have an account",
+  "I_DONT_HAVE_AN_ACCOUNT": "I don't have an account",
+  "LOGIN": "Login",
+  "LOGIN_AGAIN": "Login again",
+  "CREATE_ACCOUNT": "Create an account",
+  "BACK_TO_HOME": "Bring me back to the homepage"
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -14,6 +14,8 @@
   "TOO_MANY_CHILDREN": "One item has too many children for the operation to proceed",
   "INVALID_MOVE_TARGET": "You cannot move items to the item you selected",
   "MEMBER_NOT_FOUND": "A user was not found",
+  "MEMBER_UNAUTHORIZED": "You are not authorized to access this. Please log in with a user that is authorized to access this.",
+  "UNEXPECTED_LOGIN_ERROR": "An unexpected error occurred during login. Please log in again.",
   "CANNOT_MODIFY_OTHER_MEMBERS": "You cannot modify another user",
   "TOO_MANY_MEMBERSHIP": "One item has too many memberships for the operation to proceed",
   "MEMBER_CANNOT_ACCESS": "A user does not have access to an item",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as MemberOnlyRouteImport } from './routes/_memberOnly'
 import { Route as LandingRouteImport } from './routes/_landing'
 import { Route as PlayerIndexRouteImport } from './routes/player/index'
 import { Route as BuilderIndexRouteImport } from './routes/builder/index'
+import { Route as AuthIndexRouteImport } from './routes/auth/index'
 import { Route as AnalyticsIndexRouteImport } from './routes/analytics/index'
 import { Route as LandingIndexRouteImport } from './routes/_landing/index'
 import { Route as EmailChangeRouteImport } from './routes/email.change'
@@ -87,6 +88,11 @@ const BuilderIndexRoute = BuilderIndexRouteImport.update({
   id: '/builder/',
   path: '/builder/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AuthIndexRoute = AuthIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AuthRoute,
 } as any)
 const AnalyticsIndexRoute = AnalyticsIndexRouteImport.update({
   id: '/',
@@ -311,6 +317,7 @@ export interface FileRoutesByFullPath {
   '/email/change': typeof EmailChangeRoute
   '/': typeof LandingIndexRoute
   '/analytics/': typeof AnalyticsIndexRoute
+  '/auth/': typeof AuthIndexRoute
   '/builder': typeof BuilderIndexRoute
   '/player': typeof PlayerIndexRoute
   '/home': typeof MemberOnlyHomeLayoutHomeRoute
@@ -334,7 +341,6 @@ export interface FileRoutesByFullPath {
   '/builder/items/$itemId/share': typeof BuilderItemsItemIdItemPageShareRoute
 }
 export interface FileRoutesByTo {
-  '/auth': typeof AuthRouteWithChildren
   '/signin': typeof SigninRoute
   '/about-us': typeof LandingAboutUsRoute
   '/contact-us': typeof LandingContactUsRoute
@@ -353,6 +359,7 @@ export interface FileRoutesByTo {
   '/email/change': typeof EmailChangeRoute
   '/': typeof LandingIndexRoute
   '/analytics': typeof AnalyticsIndexRoute
+  '/auth': typeof AuthIndexRoute
   '/builder': typeof BuilderIndexRoute
   '/player': typeof PlayerIndexRoute
   '/home': typeof MemberOnlyHomeLayoutHomeRoute
@@ -397,6 +404,7 @@ export interface FileRoutesById {
   '/email/change': typeof EmailChangeRoute
   '/_landing/': typeof LandingIndexRoute
   '/analytics/': typeof AnalyticsIndexRoute
+  '/auth/': typeof AuthIndexRoute
   '/builder/': typeof BuilderIndexRoute
   '/player/': typeof PlayerIndexRoute
   '/_memberOnly/_homeLayout/home': typeof MemberOnlyHomeLayoutHomeRoute
@@ -443,6 +451,7 @@ export interface FileRouteTypes {
     | '/email/change'
     | '/'
     | '/analytics/'
+    | '/auth/'
     | '/builder'
     | '/player'
     | '/home'
@@ -466,7 +475,6 @@ export interface FileRouteTypes {
     | '/builder/items/$itemId/share'
   fileRoutesByTo: FileRoutesByTo
   to:
-    | '/auth'
     | '/signin'
     | '/about-us'
     | '/contact-us'
@@ -485,6 +493,7 @@ export interface FileRouteTypes {
     | '/email/change'
     | '/'
     | '/analytics'
+    | '/auth'
     | '/builder'
     | '/player'
     | '/home'
@@ -528,6 +537,7 @@ export interface FileRouteTypes {
     | '/email/change'
     | '/_landing/'
     | '/analytics/'
+    | '/auth/'
     | '/builder/'
     | '/player/'
     | '/_memberOnly/_homeLayout/home'
@@ -617,6 +627,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/builder'
       preLoaderRoute: typeof BuilderIndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/auth/': {
+      id: '/auth/'
+      path: '/'
+      fullPath: '/auth/'
+      preLoaderRoute: typeof AuthIndexRouteImport
+      parentRoute: typeof AuthRoute
     }
     '/analytics/': {
       id: '/analytics/'
@@ -981,6 +998,7 @@ interface AuthRouteChildren {
   AuthResetPasswordRoute: typeof AuthResetPasswordRoute
   AuthSigninRoute: typeof AuthSigninRoute
   AuthSuccessRoute: typeof AuthSuccessRoute
+  AuthIndexRoute: typeof AuthIndexRoute
 }
 
 const AuthRouteChildren: AuthRouteChildren = {
@@ -990,6 +1008,7 @@ const AuthRouteChildren: AuthRouteChildren = {
   AuthResetPasswordRoute: AuthResetPasswordRoute,
   AuthSigninRoute: AuthSigninRoute,
   AuthSuccessRoute: AuthSuccessRoute,
+  AuthIndexRoute: AuthIndexRoute,
 }
 
 const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren)

--- a/src/routes/auth/index.tsx
+++ b/src/routes/auth/index.tsx
@@ -1,0 +1,94 @@
+import { useTranslation } from 'react-i18next';
+
+import { Stack, Typography } from '@mui/material';
+
+import { createFileRoute } from '@tanstack/react-router';
+import { zodValidator } from '@tanstack/zod-adapter';
+import { CircleUserIcon, UserPlusIcon } from 'lucide-react';
+import { z } from 'zod';
+
+import { ButtonLink } from '@/components/ui/ButtonLink';
+import { TypographyLink } from '@/components/ui/TypographyLink';
+import { NS } from '@/config/constants';
+import { useButtonColor } from '@/ui/buttons/hooks';
+
+const authErrorSchema = z.object({
+  error: z.string().optional(),
+});
+
+export const Route = createFileRoute('/auth/')({
+  validateSearch: zodValidator(authErrorSchema),
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const search = Route.useSearch();
+  const { t } = useTranslation(NS.Auth);
+  const { color: primaryColor } = useButtonColor('primary');
+
+  if (search.error) {
+    return (
+      <Stack gap={2} p={2} alignItems="center" width="100%">
+        <AuthError error={search.error} />
+        <ButtonLink to="/auth/login" variant="contained" color="primary">
+          {t('LOGIN_AGAIN')}
+        </ButtonLink>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack
+      direction="column"
+      gap={6}
+      m="auto"
+      p={2}
+      alignItems="center"
+      maxWidth="md"
+      width="100%"
+    >
+      <Stack gap={2} alignItems="center" width="100%">
+        <Typography variant="h2">{t('WELCOME')}</Typography>
+        <Typography variant="body1">{t('WELCOME_MESSAGE')}</Typography>
+      </Stack>
+      <Stack
+        direction="row"
+        gap={4}
+        justifyContent="space-between"
+        width="100%"
+      >
+        <Stack flex="1 0 1" alignItems="center" gap={1} width="100%">
+          <CircleUserIcon size="34" color={primaryColor} />
+          <Typography variant="body1">{t('I_HAVE_AN_ACCOUNT')}</Typography>
+          <ButtonLink variant="contained" to="/auth/login">
+            {t('LOGIN')}
+          </ButtonLink>
+        </Stack>
+        <Stack flex="1 0 1" alignItems="center" gap={1} width="100%">
+          <UserPlusIcon size="34" color={primaryColor} />
+          <Typography variant="body1">{t('I_DONT_HAVE_AN_ACCOUNT')}</Typography>
+          <ButtonLink variant="contained" to="/auth/register">
+            {t('CREATE_ACCOUNT')}
+          </ButtonLink>
+        </Stack>
+      </Stack>
+      <TypographyLink to="/" variant="body1" color="text.secondary">
+        {t('BACK_TO_HOME')}
+      </TypographyLink>
+    </Stack>
+  );
+}
+
+function AuthError({ error }: { error: string }) {
+  const { t } = useTranslation(NS.Messages);
+  if (error === 'MEMBER_NOT_FOUND') {
+    return <div>{t('MEMBER_NOT_FOUND')}</div>;
+  }
+  if (error === 'Unauthorized member') {
+    return <div>{t('MEMBER_UNAUTHORIZED')}</div>;
+  }
+  if (error === 'TOKEN_EXPIRED') {
+    return <div>{t('TOKEN_EXPIRED')}</div>;
+  }
+  return <div>{t('UNEXPECTED_LOGIN_ERROR')}</div>;
+}


### PR DESCRIPTION
In this PR:
- handle the new `error` query parameter values sent by the backend on unsuccessful login attempt
  - Login can fail because the token is expired, the member is not found, any other error that is unexpected
  - the user should have the possibility to login again
- pimp up the `/auth` page (previously completely blank)
