### PR TITLE
fix: remove react-fullscreen-crossbrowser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "react-dnd": "16.0.1",
     "react-dnd-html5-backend": "16.0.1",
     "react-dom": "19.1.1",
-    "react-fullscreen-crossbrowser": "1.1.3",
     "react-helmet-async": "2.0.5",
     "react-hook-form": "7.54.2",
     "react-i18next": "16.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,9 +152,6 @@ importers:
       react-dom:
         specifier: 19.1.1
         version: 19.1.1(react@19.1.1)
-      react-fullscreen-crossbrowser:
-        specifier: 1.1.3
-        version: 1.1.3
       react-helmet-async:
         specifier: 2.0.5
         version: 2.0.5(react@19.1.1)
@@ -5713,9 +5710,6 @@ packages:
 
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
-
-  react-fullscreen-crossbrowser@1.1.3:
-    resolution: {integrity: sha512-z1iOYRnciP+rcgH5t+TDAeFmUmBUAwK5hRkiTg0Rn7VbI0YYcgRRcIVM2hT3fDla7kcT+bXRuIEpZO+54r0P+w==}
 
   react-helmet-async@2.0.5:
     resolution: {integrity: sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==}
@@ -13125,8 +13119,6 @@ snapshots:
       react: 19.1.1
 
   react-fast-compare@3.2.2: {}
-
-  react-fullscreen-crossbrowser@1.1.3: {}
 
   react-helmet-async@2.0.5(react@19.1.1):
     dependencies:

--- a/src/modules/player/rightPanel/SideContent.tsx
+++ b/src/modules/player/rightPanel/SideContent.tsx
@@ -1,5 +1,4 @@
-import type { JSX } from 'react';
-import Fullscreen from 'react-fullscreen-crossbrowser';
+import { useEffect, useRef, type JSX } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { IconButton, Stack, Tooltip, styled } from '@mui/material';
@@ -57,6 +56,13 @@ const StyledIconButton = styled(IconButton)({
   zIndex: FLOATING_BUTTON_Z_INDEX,
 });
 
+const StyledFullscreenContainer = styled('div')(({ theme }) => ({
+  backgroundColor: theme.palette.background.default,
+  '&::backdrop': {
+    backgroundColor: theme.palette.background.default,
+  },
+}));
+
 type Props = {
   item: GenericItem;
   content: JSX.Element;
@@ -81,6 +87,18 @@ const SideContent = ({ content, item }: Props): JSX.Element | null => {
 
   const { t } = useTranslation(NS.Player);
   const settings = item.settings ?? {};
+  const fullscreenRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleFullscreenChange = (): void => {
+      setIsFullscreen(Boolean(document.fullscreenElement));
+    };
+
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+
+    return () =>
+      document.removeEventListener('fullscreenchange', handleFullscreenChange);
+  }, [setIsFullscreen]);
 
   if (!rootId) {
     return null;
@@ -92,7 +110,21 @@ const SideContent = ({ content, item }: Props): JSX.Element | null => {
   const pinnedCount = pinnedItems?.length ?? 0;
 
   const toggleFullscreen = () => {
-    setIsFullscreen(!isFullscreen);
+    const fullscreenElement = fullscreenRef.current;
+
+    if (!fullscreenElement) {
+      return;
+    }
+
+    const fullscreenAction = document.fullscreenElement
+      ? document.exitFullscreen()
+      : fullscreenElement.requestFullscreen();
+
+    fullscreenAction.catch((err) => {
+      console.error(
+        `Error attempting to toggle fullscreen mode: ${err.message} (${err.name})`,
+      );
+    });
   };
 
   const displayFullscreenButton = () => {
@@ -163,10 +195,7 @@ const SideContent = ({ content, item }: Props): JSX.Element | null => {
   };
 
   return (
-    <Fullscreen
-      enabled={isFullscreen}
-      onChange={(isFullscreenEnabled) => setIsFullscreen(isFullscreenEnabled)}
-    >
+    <StyledFullscreenContainer ref={fullscreenRef}>
       {displayChatbox()}
       {displayPinnedItems()}
       <Stack id="contentGrid">
@@ -178,7 +207,7 @@ const SideContent = ({ content, item }: Props): JSX.Element | null => {
           {content}
         </StyledMain>
       </Stack>
-    </Fullscreen>
+    </StyledFullscreenContainer>
   );
 };
 

--- a/src/modules/player/rightPanel/SideContent.tsx
+++ b/src/modules/player/rightPanel/SideContent.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type JSX } from 'react';
+import { type JSX, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { IconButton, Stack, Tooltip, styled } from '@mui/material';


### PR DESCRIPTION
Removed `react-fullscreen-browser` dependency from `SideContent.tsx` and `package.json`

- Replaced `react-fullscreen-browser` with manual fullscreen handling
- EXTRA: fixed visual bug where screen turned black in fullscreen mode while in player mode

close #1218 