### PR TITLE
fix: allow attributes on html document

### DIFF
--- a/src/ui/TextDisplay/TextDisplay.tsx
+++ b/src/ui/TextDisplay/TextDisplay.tsx
@@ -31,7 +31,7 @@ const TextDisplay = ({
       <StyledDiv className="quill" id={id}>
         <div className="ql-snow ql-disabled">
           <div className="ql-editor">
-            <Interweave content={content} noWrap />
+            <Interweave content={content} noWrap allowAttributes />
           </div>
         </div>
       </StyledDiv>


### PR DESCRIPTION
In this PR I allow attributes on the custom html so that we can render ordered lists for example.